### PR TITLE
FIX Multiple addresses in to, cc or bcc

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -191,7 +191,7 @@ class PoweremailMailbox(osv.osv):
         emails = email.split(',')
         if len(emails)>0:
             for email in emails:
-                if not get_validate_email(email):
+                if not get_validate_email(email.strip()):
                     return False
                     break
         return True


### PR DESCRIPTION
If a blank between the comma separator and next address,
created mail went to draft, not outbox because of address validation failure
