### PR TITLE
FIX Error de codificació password amb CRAMMD5

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -263,7 +263,8 @@ class poweremail_core_accounts(osv.osv):
                 try:
                     if serv.has_extn('AUTH'):
                         if this_object.smtpuname or this_object.smtppass:
-                            serv.login(this_object.smtpuname, this_object.smtppass)
+                            serv.login(this_object.smtpuname,
+                                       this_object.smtppass.encode('ascii'))
                 except Exception, error:
                     raise error
                 return serv


### PR DESCRIPTION
Quan el servidor de correu utilitza TLS i el mètode de autentificació és
CRAM-MD5 el password no pot ser un text unicode, ja que falla la llibreria
smtplib.

Codifiquem el password en ascii per evitar el problema.
