### PR TITLE
Updated email create on poweremail_mailbox.create

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -282,8 +282,11 @@ class PoweremailMailbox(osv.osv):
         return True
 
     def create(self, cursor, user, vals, context=None):
-        mail = qreu.Email(vals['pem_mail_orig'])
-        vals['pem_subject'] = mail.subject
+        mail = qreu.Email(vals.get('pem_mail_orig', False))
+        if mail and mail.subject:
+            vals['pem_subject'] = mail.subject
+        else:
+            vals['pem_subject'] = vals.get('pem_subject', '')
         for field in ('pem_to', 'pem_cc', 'pem_bcc'):
             if field in vals:
                 vals[field] = filter_send_emails(vals[field])

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -282,11 +282,8 @@ class PoweremailMailbox(osv.osv):
         return True
 
     def create(self, cursor, user, vals, context=None):
-        mail = qreu.Email(vals.get('pem_mail_orig', False))
-        if mail and mail.subject:
-            vals['pem_subject'] = mail.subject
-        else:
-            vals['pem_subject'] = vals.get('pem_subject', '')
+        if vals.get('pem_mail_orig', False):
+            vals['pem_subject'] = qreu.Email(vals['pem_mail_orig']).subject
         for field in ('pem_to', 'pem_cc', 'pem_bcc'):
             if field in vals:
                 vals[field] = filter_send_emails(vals[field])


### PR DESCRIPTION
Mailbox.create required _vals['pem_mail_orig']_. It was only used to build a mail object and override the _subject_ from _vals_. 

Now tries to get subject from mail_orig if there is one else use subject in vals or ''.
So:
Deleted requirement of the following fields on _poweremail.mailbox.create_:

- 'pem_mail_orig'
- 'pem_subject'