### PR TITLE
Imp validate mail  addresses

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -260,6 +260,18 @@ class PoweremailMailbox(osv.osv):
             self.pool.get('poweremail.core_accounts').get_fullmail(cr, uid, id, context)
             self.historise(cr, uid, [id], "Full email downloaded", context)
 
+    def is_valid(self, cursor, uid, mail_id, context=None):
+        fields_to_read = ['pem_to', 'pem_cc', 'pem_bcc']
+        mail = self.read(cursor, uid, mail_id, fields_to_read, context)
+        check_email = self.check_email_valid(mail['pem_to'])
+        if mail['pem_cc']:
+            check_email = check_email and self.check_email_valid(mail['pem_cc'])
+        if mail['pem_bcc']:
+            check_email = check_email and self.check_email_valid(
+                mail['pem_bcc'])
+        return check_email
+
+
     def check_email_valid(self, email):
         """Check if email is valid. Check @ and .
         :email str

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -263,14 +263,10 @@ class PoweremailMailbox(osv.osv):
     def is_valid(self, cursor, uid, mail_id, context=None):
         fields_to_read = ['pem_to', 'pem_cc', 'pem_bcc']
         mail = self.read(cursor, uid, mail_id, fields_to_read, context)
-        check_email = self.check_email_valid(mail['pem_to'])
-        if mail['pem_cc']:
-            check_email = check_email and self.check_email_valid(mail['pem_cc'])
-        if mail['pem_bcc']:
-            check_email = check_email and self.check_email_valid(
-                mail['pem_bcc'])
-        return check_email
-
+        for field in fields_to_read:
+            if mail[field] and not self.check_email_valid(mail[field]):
+                return False
+        return True
 
     def check_email_valid(self, email):
         """Check if email is valid. Check @ and .


### PR DESCRIPTION
FIX validate address because when it validates addresses from the first email from list instead validate mail to mail to move it on 'draft' folder

``` python
check_email = True
....
if len(mailid)>0:
   mail = mailbox_obj.browse(cr, uid, mailid[0], context)
   check_email = mail.pem_to and mailbox_obj.check_email_valid(mail.pem_to) or False
   ...
if not check_email:
   values = {'folder':'drafts'}

mailbox_obj.write(cr, uid, mailid, values, context)
``` 
