### PR TITLE
[DONE] Remove value and action on template create

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1074,7 +1074,7 @@ class poweremail_templates(osv.osv):
                 'ref_ir_act_window': ref_ir_act_window,
                 'ref_ir_value': ref_ir_value,
             })
-        else:
+        elif not template.ref_ir_value:
             ref_ir_value = values_obj.create(
                 cursor, uid, {
                     'name': _('Send Mail (%s)') % template.name,

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -408,7 +408,8 @@ class poweremail_templates(osv.osv):
     }
 
     _defaults = {
-
+        'ref_ir_act_window': False,
+        'ref_ir_value': False
     }
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -464,38 +464,15 @@ class poweremail_templates(osv.osv):
                 obj.template_hooks['sow'] += [template.id]
 
     def create(self, cr, uid, vals, context=None):
-        id = super(poweremail_templates, self).create(cr, uid, vals, context)
-        src_obj = self.pool.get('ir.model').read(cr, uid, vals['object_name'], ['model'], context)['model']
-        vals['ref_ir_act_window'] = self.pool.get('ir.actions.act_window').create(cr, uid, {
-             'name': _("%s Mail Form") % vals['name'],
-             'type': 'ir.actions.act_window',
-             'res_model': 'poweremail.send.wizard',
-             'src_model': src_obj,
-             'view_type': 'form',
-             'context': "{'src_model':'%s','template_id':'%d','src_rec_id':active_id,'src_rec_ids':active_ids}" % (src_obj, id),
-             'view_mode':'form,tree',
-             'view_id': self.pool.get('ir.ui.view').search(cr, uid, [('name', '=', 'poweremail.send.wizard.form')], context=context)[0],
-             'target': 'new',
-             'auto_refresh':1
-        }, context)
-        vals['ref_ir_value'] = self.pool.get('ir.values').create(cr, uid, {
-             'name': _('Send Mail (%s)') % vals['name'],
-             'model': src_obj,
-             'key2': 'client_action_multi',
-             'value': "ir.actions.act_window," + str(vals['ref_ir_act_window']),
-             'object': True,
-         }, context)
-        self.write(cr, uid, id, {
-            'ref_ir_act_window': vals['ref_ir_act_window'],
-            'ref_ir_value': vals['ref_ir_value'],
-        }, context)
+        this_id = super(poweremail_templates, self).create(cr, uid, vals, context)
+
         if vals.get('auto_email'):
-            self.update_auto_email(cr, uid, [id], context)
+            self.update_auto_email(cr, uid, [this_id], context)
         if vals.get('send_on_create') or vals.get('send_on_write'):
-            self.update_send_on_store(cr, uid, [id], context)
+            self.update_send_on_store(cr, uid, [this_id], context)
         #if vals.get('partner_event'):
-        #    self.update_partner_event(cr, uid, [id], context)
-        return id
+        #    self.update_partner_event(cr, uid, [this_id], context)
+        return this_id
 
     def write(self, cr, uid, ids, vals, context=None):
         result = super(poweremail_templates, self).write(cr, uid, ids, vals, context)

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -230,7 +230,11 @@
                                 colspan="4" />
                             <group colspan="4" col="6">
                                 <field name="ref_ir_act_window" colspan="2"/>
-                                <button string="Create action and value" colspan="1" name="create_action_reference" type="object"/>
+                                <button
+                                        string="Create action and value"
+                                        colspan="1" name="create_action_reference"
+                                        type="object"
+                                        attrs="{'readonly':[('ref_ir_act_window', '!=', False), ('ref_ir_value', '!=', False)]}"/>
                                 <field name="ref_ir_value" colspan="2"/>
                             </group>
                             <field name="server_action" readonly="1" />

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -228,9 +228,12 @@
                             </group>
                             <separator string="Email action and wizard"
                                 colspan="4" />
+                            <group colspan="4" col="6">
+                                <field name="ref_ir_act_window" colspan="2"/>
+                                <button string="Create action and value" colspan="1" name="create_action_reference" type="object"/>
+                                <field name="ref_ir_value" colspan="2"/>
+                            </group>
                             <field name="server_action" readonly="1" />
-                            <field name="ref_ir_act_window" />
-                            <field name="ref_ir_value" />
                             <separator string="Attachments (Report to attach)"
                                 colspan="4" />
                             <field name="file_name" colspan="2" />


### PR DESCRIPTION
New poweremail templates shouldn't create an action and value to send it. It should be placed somewhere like in a button or a wizard.

- [x] Remove create action and value on poweremail.templates create method
- [x] Add "False" as default reference to action and value
- [x] Add button to create action and value for a mail