### PR TITLE
Fix email body send with send_pref as 'both'

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -487,7 +487,7 @@ class poweremail_core_accounts(osv.osv):
                         msg.attach(MIMEText(body_text.encode("utf-8"), _charset='UTF-8'))
                     if core_obj.send_pref == 'html' or core_obj.send_pref == 'both':
                         html_body = body.get('html', u'')
-                        if core_obj.send_pref == 'html' and (len(html_body) == 0 or html_body == u''):
+                        if len(html_body) == 0 or html_body == u'':
                             html_body = body.get('text', u'<p>No Mail Message</p>').replace('\n', '<br/>').replace('\r', '<br/>')
                         html_body = tools.ustr(html_body)
                         msg.attach(MIMEText(html_body.encode("utf-8"), _subtype='html', _charset='UTF-8'))

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -457,7 +457,7 @@ class poweremail_core_accounts(osv.osv):
             serv = self.smtp_connection(cr, uid, id)
             if serv:
                 try:
-                    msg = MIMEMultipart()
+                    msg = MIMEMultipart(_subtype='alternative')
                     for header, value in context.get('headers', {}).items():
                         msg.add_header(header, value)
                     if subject:

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -487,7 +487,7 @@ class poweremail_core_accounts(osv.osv):
                         msg.attach(MIMEText(body_text.encode("utf-8"), _charset='UTF-8'))
                     if core_obj.send_pref == 'html' or core_obj.send_pref == 'both':
                         html_body = body.get('html', u'')
-                        if len(html_body) == 0 or html_body == u'':
+                        if core_obj.send_pref == 'html' and (len(html_body) == 0 or html_body == u''):
                             html_body = body.get('text', u'<p>No Mail Message</p>').replace('\n', '<br/>').replace('\r', '<br/>')
                         html_body = tools.ustr(html_body)
                         msg.attach(MIMEText(html_body.encode("utf-8"), _subtype='html', _charset='UTF-8'))


### PR DESCRIPTION
When sending an e-mail with core account send preference as "both", it'll attatch body text 2 times if no html found on context.

This PR avoids this behaviour by adding body text only when html is set at send preference.