### PR TITLE
Fix onchange of model on poweremail.templates

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -206,18 +206,16 @@ class poweremail_templates(osv.osv):
     _name = "poweremail.templates"
     _description = 'Power Email Templates for Models'
 
-    def change_model(self, cursor, user, ids, object_name, context=None):
-        if object_name:
+    def change_model(self, cursor, user, template_id, model_id, context=None):
+        if model_id:
             mod_name = self.pool.get('ir.model').read(
-                                              cursor,
-                                              user,
-                                              object_name,
-                                              ['model'], context)['model']
+                cursor, user, model_id, ['model'], context
+            )['model']
         else:
             mod_name = False
-        return {
-                'value':{'model_int_name':mod_name}
-                }
+        val = {'model_int_name': mod_name}
+        self.pool.get('poweremail.templates').write(
+            cursor, user, template_id, val)
 
     _columns = {
         'name' : fields.char('Name of Template', size=100, required=True),

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -174,18 +174,18 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
                 context = {}
             ctx = context.copy()
             ctx.update({'browse_reference': True})
-            object = pool.get(template.model_int_name).browse(cursor, user,
-                                                              recid, ctx)
+            object = pool.get(template.object_name.model).browse(cursor, user, recid, ctx)
             env = {
-                'user':pool.get('res.users').browse(cursor, user, user, context),
-                'db':cursor.dbname
-                   }
+                'user': pool.get('res.users').browse(
+                    cursor, user, user, context),
+                'db': cursor.dbname
+            }
             if template.template_language == 'mako':
                 templ = MakoTemplate(message, input_encoding='utf-8')
-                reply = MakoTemplate(message).render_unicode(object=object,
-                                                             peobject=object,
-                                                             env=env,
-                                                             format_exceptions=True)
+                reply = templ.render_unicode(
+                    object=object, peobject=object,
+                    env=env, format_exceptions=True
+                )
             elif template.template_language == 'django':
                 templ = DjangoTemplate(message)
                 env['object'] = object

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -91,8 +91,7 @@
             <field name="arch" type="xml">
                 <form string="Power Email Templates">
                     <field name="name" />
-                    <field name="object_name" required="1"
-                        on_change="change_model(object_name)" />
+                    <field name="object_name" required="1"/>
                     <field name="model_int_name" invisible="1" />
                     <notebook colspan="4">
                         <page string="Mail Details">


### PR DESCRIPTION
PRE:On change Model of Poweremail Templates does not update the field `model_int_name`

REASON: _field `model_int_name` is "invisible" so it cannot be updated in onChange method. OnChange method runs on Client-side and won't save "invisible" and/or "read-only" fields_

SOLUTION: Convert the field to `field.function`
