### PR TITLE
Make visible the field attachments by adding height on the view field.

### DIFF
--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -69,7 +69,7 @@
 						<page string="Attachments">
 							<group col="4">
 								<separator colspan="4" string="Attachments" />
-								<field name="pem_attachments_ids" colspan="4" nolabel="1" />
+								<field name="pem_attachments_ids" colspan="4" nolabel="1" height="400"/>
 							</group>
 						</page>
 						<page string="Advanced">


### PR DESCRIPTION
 * The field had 0 height by default and the attached files were imposible to select. Now the field is perfectly visible.
![image](https://user-images.githubusercontent.com/29370959/34197421-b7f5e776-e566-11e7-897d-79fc379155a6.png)
