### PR TITLE
Fix: Don't use subtype alternative

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -457,7 +457,7 @@ class poweremail_core_accounts(osv.osv):
             serv = self.smtp_connection(cr, uid, id)
             if serv:
                 try:
-                    msg = MIMEMultipart(_subtype='alternative')
+                    msg = MIMEMultipart()
                     for header, value in context.get('headers', {}).items():
                         msg.add_header(header, value)
                     if subject:


### PR DESCRIPTION
Revert https://github.com/gisce/poweremail/pull/34 because some mail clients don't read correctly the attachments when using 'alternative'.