### PR TITLE
ADD MIME Type and Subtype usage from Mailbox

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -457,7 +457,24 @@ class poweremail_core_accounts(osv.osv):
             serv = self.smtp_connection(cr, uid, id)
             if serv:
                 try:
-                    msg = MIMEMultipart()
+                    msgtype = context.get('MIME_type', False)
+                    if msgtype:
+                        mime_type, mime_subtype = msgtype.split('/')
+                        if mime_type == 'multipart' and mime_subtype in [
+                            'mixed', 'alternative', 'related'
+                        ]:
+                            msg = MIMEMultipart(_subtype=mime_subtype)
+                        elif mime_type == 'text' and mime_subtype in [
+                            'plain', 'html'
+                        ]:
+                            msg = MIMEText(_subtype=mime_subtype)
+                        else:
+                            raise Exception(_(
+                                'Msg Type "{}" not Allowed'.format(
+                                    msgtype
+                                )))
+                    else:
+                        msg = MIMEMultipart()
                     for header, value in context.get('headers', {}).items():
                         msg.add_header(header, value)
                     if subject:

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -168,12 +168,14 @@ class PoweremailMailbox(osv.osv):
                     ])
                     if not headers.get('In-Reply-To', ''):
                         headers['In-Reply-To'] = mails[-1].pem_message_id
+                ctx = context.copy()
+                ctx.update({'MIME_subtype': values['mail_type'] or False})
                 result = core_obj.send_mail(cr, uid,
                                   [values['pem_account_id'][0]],
                                   {'To':values.get('pem_to', u'') or u'', 'CC':values.get('pem_cc', u'') or u'', 'BCC':values.get('pem_bcc', u'') or u''},
                                   values['pem_subject'] or u'',
                                   {'text':values.get('pem_body_text', u'') or u'', 'html':values.get('pem_body_html', u'') or u''},
-                                  payload=payload, context=context)
+                                  payload=payload, context=ctx)
                 if result == True:
                     self.write(cr, uid, id, {'folder':'sent', 'state':'na', 'date_mail':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
                     self.historise(cr, uid, [id], "Email sent successfully", context)


### PR DESCRIPTION
Solves #41 

Use `PoweremailMailbox.mail_type` attribute on `PoweremailCore.send_mail()` method.

> Yes, it wasn't being used right now...

- On PoweremailCore, get attr from Context and create a msg based on the MIME Type and Subtype from that value.
  - By default creates a `MIME Multipart/Mixed` as it was being used.
- On PoweremailMailbox, on `send_this_mail` method, add the pem `mail_type` value to the context.

> We may search for more usage of this method to avoid malfunctions