### PR TITLE
FIX qreu usage with new API and replace the send_mail's MIMEs with qreu's Email

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -308,7 +308,8 @@ class PoweremailMailbox(osv.osv):
 
     def create(self, cursor, user, vals, context=None):
         if vals.get('pem_mail_orig', False):
-            vals['pem_subject'] = qreu.Email(vals['pem_mail_orig']).subject
+            mail = qreu.Email.parse(vals['pem_mail_orig'])
+            vals['pem_subject'] = mail.subject
         for field in ('pem_to', 'pem_cc', 'pem_bcc'):
             if field in vals:
                 vals[field] = filter_send_emails(vals[field])
@@ -490,7 +491,7 @@ class PoweremailMailboxConversation(osv.osv):
         :return: conversation_id
         """
 
-        mail = qreu.Email(raw_email)
+        mail = qreu.Email.parse(raw_email)
         if not mail:
             return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 mako
-qreu
+qreu>=0.4.0


### PR DESCRIPTION
Fixes qreu library usage due to API changing request on PR [qreu/#4](https://github.com/gisce/qreu/pull/4).

Also change the send_mail method to work with qreu.Email instead of building MIME Messages:
- Use qreu's Email to create a MIME Message properly
- Now get the address list outside the loop and fails if empty
- Now really tries all allowed accounts to send the mail
- Now ignores account-prefered Message, using 'multipart/mixed' with body as 'multipart/alternative'
- Upgraded exception logging
- Correctly send messages to all recipients (was using only TO and CC)
- Updated send_mail to PEP8

----

**PENDING: _Test the send_mail on a real environment_**