### PR TITLE
TO MERGE:Add quotes to address character parsing

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -421,9 +421,11 @@ class poweremail_core_accounts(osv.osv):
         "a@b.com,c@bcom; d@b.com;e@b.com->['a@b.com',...]"
         """
         email_sep_by_commas = ids_as_str \
-                                    .replace('; ', ',') \
-                                    .replace(';', ',') \
-                                    .replace(', ', ',')
+            .replace('; ', ',') \
+            .replace(';', ',')  \
+            .replace(', ', ',') \
+            .replace('"', '')   \
+            .replace("'", "")
         return email_sep_by_commas.split(',')
 
     def get_ids_from_dict(self, addresses={}):


### PR DESCRIPTION
This change prevents sendmail from failing due to a list of quoted addresses on recipes addresses lists (TO, CC, BCC)