### PR TITLE
Re-add folder after any of the mails is invalid

### DIFF
--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -203,6 +203,8 @@ class poweremail_send_wizard(osv.osv_memory):
             for mail_id in mail_ids:
                 if not mailbox_obj.is_valid(cr, uid, mail_id):
                     values['folder'] = 'drafts'
+                else:
+                    values['folder'] = folder
                 mailbox_obj.write(cr, uid, [mail_id], values, context)
 
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
After sending an invalid email, all the emails were added to the "draft" folder.

If the mail is not valid, use "draft" as folder (current behaviour)
Else use the specified folder (expected behaviour)