### PR TITLE
ADD rendering values from context

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -185,9 +185,10 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
             })
             if template.template_language == 'mako':
                 templ = MakoTemplate(message, input_encoding='utf-8')
+                extra_render_values = env.get('extra_render_values', {}) or {}
                 reply = templ.render_unicode(
                     object=object, peobject=object,
-                    env=env, format_exceptions=True
+                    env=env, format_exceptions=True, **extra_render_values
                 )
             elif template.template_language == 'django':
                 templ = DjangoTemplate(message)


### PR DESCRIPTION
If the template must use more than one object, it cannot be rendered and it's pretty hard to build them.

We add the "extra_render_values" on the context to render extra values.

This values should not aliase with the already used values:
 - env
 - object
 - peobject
 - format_exceptions

To test:
- [ ] Render without any value in extra values
- [x] Render with extra values
- [ ] Render with any other vals used in rendering