### PR TITLE
Improve sending with custom from address

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -455,6 +455,10 @@ class poweremail_core_accounts(osv.osv):
         try:
             addresses_list = self.get_ids_from_dict(addresses)
             sender_address = Address(addresses_list.get('FROM' or False))
+            sender_str = u'{} <{}>'.format(
+                sender_address.display_name,
+                sender_address.address
+            )
         except Exception as error:
             logger.notifyChannel(
                 _("Power Email"), netsvc.LOG_ERROR,
@@ -480,27 +484,22 @@ class poweremail_core_accounts(osv.osv):
                 try:
                     sender_name = account.name + " <" + account.email_id + ">"
                     if (
-                        sender_address and
-                        sender_name != sender_address and
-                        sender_address not in sender_name
+                        sender_address and sender_str and
+                        sender_name != sender_str and
+                        sender_str not in sender_name
                     ):
                         sender_name = parseaddr(sender_name)
                         sender_name = u'{} <{}>'.format(
-                            sender_address.display_name,
-                            sender_name.address
+                            (
+                                sender_address.display_name
+                                if sender_address.display_name
+                                else sender_name.display_name
+                            ), sender_name.address
                         )
                         if addresses_list.get('BCC', False):
-                            addresses_list['BCC'].append(u'{} <{}>'.format(
-                                sender_address.display_name,
-                                sender_address.address
-                            ))
+                            addresses_list['BCC'].append(sender_str)
                         else:
-                            addresses_list['BCC'] = [
-                                u'{} <{}>'.format(
-                                    sender_address.display_name,
-                                    sender_address.address
-                                )
-                            ]
+                            addresses_list['BCC'] = [sender_str]
                         addresses_list['BCC'] = list(set(addresses_list['BCC']))
                     body_html = (
                         tools.ustr(body.get('html', '')) or

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -481,7 +481,11 @@ class poweremail_core_accounts(osv.osv):
                         tools.ustr(body.get('html', '')) or
                         tools.ustr(body.get('text', ''))
                     )
-                    if "<br/>" not in body_html and "<br>" not in body_html:
+                    if (
+                        body_html.strip()[0] != '<' and
+                        "<br/>" not in body_html and
+                        "<br>" not in body_html
+                    ):
                         body_html = body_html.replace('\n', '<br/>')
                     mail = Email(**{
                         'subject': subject,

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -482,8 +482,8 @@ class poweremail_core_accounts(osv.osv):
             sender_addr = pem_account
             if from_addr:
                 # If custom from address
-                from_addr = parseaddr(from_addr)
-                account_addr = parseaddr(pem_account)
+                from_addr = Address(*parseaddr(from_addr))
+                account_addr = Address(*parseaddr(pem_account))
                 if from_addr.display_name:
                     # If from address has display name, use it with account addr
                     sender_addr = u'{} <{}>'.format(
@@ -529,13 +529,13 @@ class poweremail_core_accounts(osv.osv):
             # Update the sender address from account
             sender_name = account.name + " <" + account.email_id + ">"
             sender_name = parse_sender(
-                pem_account=account,
+                pem_account=sender_name,
                 pem_addresses=addresses_list
             )
             # If the account is a company account, update the header
-            if account.company_id:
+            if account.user.company_id:
                 extra_headers.update({
-                    'Organitzation': account.company_id.name
+                    'Organitzation': account.user.company_id.name
                 })
             elif 'Organitzation' in extra_headers:
                 extra_headers.pop('Organitzation')

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -439,7 +439,10 @@ class poweremail_core_accounts(osv.osv):
             ids_as_list = self.split_to_ids(addresses.get(each, u''))
             while u'' in ids_as_list:
                 ids_as_list.remove(u'')
-            result[each] = ids_as_list
+            if each == 'FROM':
+                result[each] = ids_as_list[0]
+            else:
+                result[each] = ids_as_list
             result['all'].extend(ids_as_list)
         return result
 
@@ -454,11 +457,14 @@ class poweremail_core_accounts(osv.osv):
         logger = netsvc.Logger()
         try:
             addresses_list = self.get_ids_from_dict(addresses)
-            sender_address = Address(addresses_list.get('FROM' or False))
-            sender_str = u'{} <{}>'.format(
-                sender_address.display_name,
-                sender_address.address
-            )
+            sender_address = addresses_list.get('FROM', False)
+            if sender_address:
+                sender_address = parseaddr(sender_address)
+                sender_address = Address(sender_address[0], sender_address[1])
+                sender_str = u'{} <{}>'.format(
+                    sender_address.display_name,
+                    sender_address.address
+                ).strip()
         except Exception as error:
             logger.notifyChannel(
                 _("Power Email"), netsvc.LOG_ERROR,
@@ -489,6 +495,7 @@ class poweremail_core_accounts(osv.osv):
                         sender_str not in sender_name
                     ):
                         sender_name = parseaddr(sender_name)
+                        sender_name = Address(sender_name[0], sender_name[1])
                         sender_name = u'{} <{}>'.format(
                             (
                                 sender_address.display_name

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -508,8 +508,6 @@ class poweremail_core_accounts(osv.osv):
         extra_headers = context.get('headers', {})
         # Try to send the e-mail from each allowed account
         # Only one mail is sent
-        result = []
-        sent_addr = []
         for account_id in ids:
             account = self.browse(cr, uid, account_id, context)
             # Update the sender address from account

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -467,6 +467,16 @@ class poweremail_core_accounts(osv.osv):
                 )
             return mail
 
+        def parse_body_html(pem_body_html, pem_body_text):
+            html = pem_body_text if not pem_body_html else pem_body_html
+            if (
+                html.strip()[0] != '<' and
+                "<br/>" not in html and
+                "<br>" not in html
+            ):
+                html = html.replace('\n', '<br/>')
+            return html
+
         if body is None:
             body = {}
         if payload is None:
@@ -495,16 +505,10 @@ class poweremail_core_accounts(osv.osv):
             return error
         # Get email Data
         subject = subject or context.get('subject', '') or ''
-        body_html = (
-                tools.ustr(body.get('html', '')) or
-                tools.ustr(body.get('text', ''))
+        body_html = parse_body_html(
+            pem_body_html=tools.ustr(body.get('html', '')),
+            pem_body_text=tools.ustr(body.get('text', ''))
         )
-        if (
-                body_html.strip()[0] != '<' and
-                "<br/>" not in body_html and
-                "<br>" not in body_html
-        ):
-            body_html = body_html.replace('\n', '<br/>')
         extra_headers = context.get('headers', {})
         # Try to send the e-mail from each allowed account
         # Only one mail is sent

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -170,12 +170,18 @@ class PoweremailMailbox(osv.osv):
                         headers['In-Reply-To'] = mails[-1].pem_message_id
                 ctx = context.copy()
                 ctx.update({'MIME_subtype': values['mail_type'] or False})
-                result = core_obj.send_mail(cr, uid,
-                                  [values['pem_account_id'][0]],
-                                  {'To':values.get('pem_to', u'') or u'', 'CC':values.get('pem_cc', u'') or u'', 'BCC':values.get('pem_bcc', u'') or u''},
-                                  values['pem_subject'] or u'',
-                                  {'text':values.get('pem_body_text', u'') or u'', 'html':values.get('pem_body_html', u'') or u''},
-                                  payload=payload, context=ctx)
+                result = core_obj.send_mail(
+                    cr, uid, [values['pem_account_id'][0]], {
+                        'To': values.get('pem_to', u'') or u'',
+                        'CC': values.get('pem_cc', u'') or u'',
+                        'BCC': values.get('pem_bcc', u'') or u'',
+                        'FROM': values.get('pem_from',u'') or u''
+                    },
+                    values['pem_subject'] or u'', {
+                        'text': values.get('pem_body_text', u'') or u'',
+                        'html': values.get('pem_body_html', u'') or u''
+                    }, payload=payload, context=ctx
+                )
                 if result == True:
                     self.write(cr, uid, id, {'folder':'sent', 'state':'na', 'date_mail':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
                     self.historise(cr, uid, [id], "Email sent successfully", context)


### PR DESCRIPTION
Improve sending mails to use the poweremail "from" field when sending instead of account.

- Combines the "from" display name (if any) with the account's email.
- ADD the "from" address to the BCCs.
- IMP the core `send_mail` method call
- IMP the body HTML parsing