### PR TITLE
ADD attachment creation from pem_orig_mail

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -776,10 +776,12 @@ class poweremail_core_accounts(osv.osv):
                     _("Header for Mail %s Saved successfully as ID: %s for Account: %s.") % (serv_ref,
                                                   crid,
                                                   coreaccountid))
+            # Commenting this code due to the attachments being created on
+            #  mailbox's create, as we decode the email there with QREU's Email
             #If there are attachments save them as well
-            if parsed_mail['attachments']:
-                self.save_attachments(cr, uid, mail, crid,
-                                      parsed_mail, coreaccountid, context)
+            # if parsed_mail['attachments']:
+            #     self.save_attachments(cr, uid, mail, crid,
+            #                           parsed_mail, coreaccountid, context)
             crid = False
             return True
         else:
@@ -831,9 +833,12 @@ class poweremail_core_accounts(osv.osv):
         #Check if a create was success
         if crid:
             logger.notifyChannel(_("Power Email"), netsvc.LOG_INFO, _("Mail %s Saved successfully as ID: %s for Account: %s.") % (serv_ref, crid, coreaccountid))
+
+            # Commenting this code due to the attachments being created on
+            #  mailbox's create, as we decode the email there with QREU's Email
             #If there are attachments save them as well
-            if parsed_mail['attachments']:
-                self.save_attachments(cr, uid, mail, mailboxref, parsed_mail, coreaccountid, context)
+            # if parsed_mail['attachments']:
+            #     self.save_attachments(cr, uid, mail, mailboxref, parsed_mail, coreaccountid, context)
             return True
         else:
             logger.notifyChannel(_("Power Email"), netsvc.LOG_ERROR, _("IMAP Mail -> Mailbox create error Account: %s, Mail: %s") % (coreaccountid, mail[0].split()[0]))

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -1129,7 +1129,7 @@ class poweremail_core_accounts(osv.osv):
         - 'attachments': [attachments]
         """
         # Use qreu's parsing
-        parsed_mail = Email(mail)
+        parsed_mail = Email.parse(mail.as_string())
         parts = parsed_mail.body_parts
         attachments = [
             (v['type'], v['name'], v['content'])

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -341,7 +341,7 @@ class PoweremailMailbox(osv.osv):
                 })
                 attachment_ids.append(att_id)
             if attachment_ids:
-                self.write(cursor, user, {
+                self.write(cursor, user, [res_id], {
                     'pem_attachments_ids': [(6, 0, attachment_ids)]
                 })
         return res_id


### PR DESCRIPTION
Currently, no attachments are imported from the email when importing emails from a mailing server.

NEW FEATURE:

- If we are creating a PEM_Mailbox instance from an email (it has the "pem_orig_mail" field filled), then we create a mail instance using it. If it has attachments:
  - We create an instance of "ir.attachment" and link it to the poweremail_mailbox instance we have just created.
  - We write the "pem_attachment_ids" field with the created attachments
- Attachments should not be created AFTER the email creation, as the link logic should be on the poweremail_mailbox side. → I commented the original not working code so it does not create useless (wrong formatted) attachments.