### PR TITLE
Add priority to templates

### DIFF
--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -186,7 +186,7 @@ class poweremail_send_wizard(osv.osv_memory):
         'requested':lambda self,cr,uid,ctx: len(ctx['src_rec_ids']),
         'full_success': lambda *a: False,
         'single_email':lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'single_email', ctx),
-        'priority': lambda *a: '1',
+        'priority': lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_priority', ctx),
     }
 
 

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -68,6 +68,7 @@ import poweremail_engines
 import tools
 import report
 import pooler
+from .poweremail_mailbox import _priority_selection
 
 
 def send_on_create(self, cr, uid, vals, context=None):
@@ -272,6 +273,10 @@ class poweremail_templates(osv.osv):
                 'Body (Text-Web Client Only)',
                 help="The text version of the mail.",
                 translate=True),
+        'def_priority': fields.selection(
+            _priority_selection, 'Default priority',
+            help="Default priority for auto generated emails"
+        ),
         'use_sign':fields.boolean(
                 'Use Signature',
                 help="The signature from the User details "
@@ -423,7 +428,8 @@ class poweremail_templates(osv.osv):
 
     _defaults = {
         'ref_ir_act_window': False,
-        'ref_ir_value': False
+        'ref_ir_value': False,
+        'def_priority': lambda *a: '1'
     }
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))
@@ -932,7 +938,8 @@ class poweremail_templates(osv.osv):
             #This is a mandatory field when automatic emails are sent
             'state':'na',
             'folder':'drafts',
-            'mail_type':'multipart/alternative'
+            'mail_type':'multipart/alternative',
+            'priority': template.def_priority
         }
         #Use signatures if allowed
         if template.use_sign:

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -107,6 +107,7 @@
                                     required="1" />
                                 <field name="use_sign" colspan="4" />
                                 <field name="lang" colspan="4" />
+                                <field name="def_priority"/>
                             </group>
                             <separator colspan="3" string="Standard Body" />
                             <separator colspan="1"

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -14,6 +14,6 @@
 "access_pe_conversation_internal_users","poweremail.conversation","model_poweremail_conversation","res_groups_peusersi",1,1,1,1
 "access_pe_conversation_external_users","poweremail.conversation","model_poweremail_conversation","res_groups_peuserse",1,1,1,1
 "access_pe_conversation_settings_manager","poweremail.conversation","model_poweremail_conversation","res_groups_pemanager",1,1,1,1
-"access_pe_template_attachment_users","poweremail.template.attachment","model_poweremail_template_attachment","res_groups_peusersi",1,1,0,0
-"access_pe_template_attachment_users","poweremail.template.attachment","model_poweremail_template_attachment","res_groups_peuserse",1,1,0,0
+"access_pe_template_attachment_userssi","poweremail.template.attachment","model_poweremail_template_attachment","res_groups_peusersi",1,1,0,0
+"access_pe_template_attachment_usersse","poweremail.template.attachment","model_poweremail_template_attachment","res_groups_peuserse",1,1,0,0
 "access_pe_template_attachment_manager","poweremail.template.attachment","model_poweremail_template_attachment","res_groups_pemanager",1,1,1,1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+from destral import testing
+
+
+class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
+
+    def create_account(self):
+        acc_obj = self.openerp.pool.get('poweremail.core_accounts')
+        cursor = self.cursor
+        uid = self.uid
+
+        acc_id = acc_obj.create(cursor, uid, {
+            'name': 'Test account',
+            'user': self.uid,
+            'email_id': 'test@example.com',
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'smtpuname': 'test',
+            'smtppass': 'test',
+            'company': 'yes'
+        })
+        return acc_id
+
+    def create_template(self):
+
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        tmpl_obj = self.openerp.pool.get('poweremail.templates')
+        cursor = self.cursor
+        uid = self.uid
+        acc_id = self.create_account()
+
+        model_partner = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'model_res_partner'
+        )[1]
+
+        tmpl_id = tmpl_obj.create(cursor, uid, {
+            'name': 'Test template',
+            'object_name': model_partner,
+            'enforce_from_account': acc_id,
+            'template_language': 'mako',
+            'def_priority': '2'
+        })
+        return tmpl_id
+
+    def test_creating_email_gets_default_priority(self):
+
+        tmpl_obj = self.openerp.pool.get('poweremail.templates')
+        mail_obj = self.openerp.pool.get('poweremail.mailbox')
+        imd_obj = self.openerp.pool.get('ir.model.data')
+
+        cursor = self.cursor
+        uid = self.uid
+        partner_id = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'res_partner_asus'
+        )[1]
+
+        tmpl_id = self.create_template()
+
+        template = tmpl_obj.browse(cursor, uid, tmpl_id)
+
+        mailbox_id = tmpl_obj._generate_mailbox_item_from_template(
+            cursor, uid, template, partner_id
+        )
+
+        mail = mail_obj.browse(cursor, uid, mailbox_id)
+        self.assertEqual(mail.priority, '2')
+
+    def test_send_wizards_gets_default_priority_from_template(self):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        send_obj = self.openerp.pool.get('poweremail.send.wizard')
+
+        cursor = self.cursor
+        uid = self.uid
+        partner_id = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'res_partner_asus'
+        )[1]
+
+        tmpl_id = self.create_template()
+
+        wiz_id = send_obj.create(cursor, uid, {}, context={
+            'active_id': partner_id,
+            'active_ids': [partner_id],
+            'src_rec_ids': [partner_id],
+            'src_model': 'res.partner',
+            'template_id': tmpl_id
+        })
+        wiz = send_obj.browse(cursor, uid, wiz_id)
+        self.assertEqual(wiz.priority, '2')


### PR DESCRIPTION
- Add default priority to templates. This will allow us to use the new behavior of https://github.com/gisce/poweremail_oorq/pull/12
- The automatically generated mails from templates will use this priority
- The generated mails from the wizard will get the default priority from the template value.