### PR TITLE
Fix only run one unique hook

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -73,7 +73,7 @@ from .poweremail_mailbox import _priority_selection
 
 def send_on_create(self, cr, uid, vals, context=None):
     oid = self.old_create(cr, uid, vals, context)
-    for tid in self.template_hooks['soc']:
+    for tid in set(self.template_hooks['soc']):
         template = self.pool.get('poweremail.templates').browse(cr, uid, tid,
                                                                 context)
         # Ensure it's still configured to send on create
@@ -87,7 +87,7 @@ def send_on_write(self, cr, uid, ids, vals, context=None):
     if not context:
         context = {}
     result = self.old_write(cr, uid, ids, vals, context)
-    for tid in self.template_hooks['sow']:
+    for tid in set(self.template_hooks['sow']):
         template = self.pool.get('poweremail.templates').browse(cr, uid, tid,
                                                                 context)
         # Ensure it's still configured to send on write


### PR DESCRIPTION
On normal cases this did'nt will be necessary, but when we run poweremail inside `destral` some hooks may be duplicated. Making a `set` this will work