### PR TITLE
Validate body message before sending

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -170,16 +170,32 @@ class PoweremailMailbox(osv.osv):
                         headers['In-Reply-To'] = mails[-1].pem_message_id
                 ctx = context.copy()
                 ctx.update({'MIME_subtype': values['mail_type'] or False})
+                if not values.get('pem_body_html') or not values.get('pem_body_text'):
+                    raise osv.except_osv(
+                        _('Error'),
+                        _("The body of the email must not be empty.")
+                    )
+                if not values.get('pem_to', u''):
+                    raise osv.except_osv(
+                        _('Error'),
+                        _("The email must have a destiny account.")
+                    )
+                if not values.get('pem_from', u''):
+                    raise osv.except_osv(
+                        _('Error'),
+                        _("The email must have a sending account.")
+                    )
+
                 result = core_obj.send_mail(
                     cr, uid, [values['pem_account_id'][0]], {
-                        'To': values.get('pem_to', u'') or u'',
+                        'To': values['pem_to'],
                         'CC': values.get('pem_cc', u'') or u'',
                         'BCC': values.get('pem_bcc', u'') or u'',
-                        'FROM': values.get('pem_from',u'') or u''
+                        'FROM': values['pem_from']
                     },
                     values['pem_subject'] or u'', {
-                        'text': values.get('pem_body_text', u'') or u'',
-                        'html': values.get('pem_body_html', u'') or u''
+                        'text': values['pem_body_text'],
+                        'html': values['pem_body_html']
                     }, payload=payload, context=ctx
                 )
                 if result == True:

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -146,7 +146,7 @@ class PoweremailMailbox(osv.osv):
                 pem_to = (values['pem_to'] or '').strip()
                 if pem_to in ('', 'False'):
                     self.historise(cr, uid, [id],
-                                   "No recipient: Email cannot be sent",
+                                   _("No recipient: Email cannot be sent"),
                                    context, error=True)
                     continue
                 payload = {}
@@ -200,7 +200,7 @@ class PoweremailMailbox(osv.osv):
                 )
                 if result == True:
                     self.write(cr, uid, id, {'folder':'sent', 'state':'na', 'date_mail':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
-                    self.historise(cr, uid, [id], "Email sent successfully", context)
+                    self.historise(cr, uid, [id], _("Email sent successfully"), context)
                 else:
                     self.historise(cr, uid, [id], result, context, error=True)
             except Exception, error:


### PR DESCRIPTION
Errors should never pass silently unless explicitly silenced. So it's better to raise an error while validating the required fields of an email. 