### PR TITLE
Send empty string intead of "False" in case html is empty

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -195,8 +195,8 @@ class PoweremailMailbox(osv.osv):
                         'FROM': values['pem_from']
                     },
                     values['pem_subject'] or u'', {
-                        'text': values.get('pem_body_text', u''),
-                        'html': values.get('pem_body_html', u'')
+                        'text': values.get('pem_body_text') or u'',
+                        'html': values.get('pem_body_html') or u''
                     }, payload=payload, context=ctx
                 )
                 if result == True:

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -195,8 +195,8 @@ class PoweremailMailbox(osv.osv):
                         'FROM': values['pem_from']
                     },
                     values['pem_subject'] or u'', {
-                        'text': values['pem_body_text'],
-                        'html': values['pem_body_html']
+                        'text': values.get('pem_body_text', u''),
+                        'html': values.get('pem_body_html', u'')
                     }, payload=payload, context=ctx
                 )
                 if result == True:


### PR DESCRIPTION
Changing from `'html': values.get('pem_body_html') or u''` to `'html': values['pem_body_html']` caused the pem_body_html content to be filled with the word "False" instead of with an empty string. Then the email client shows the word "False" instead of the content from the pem_body_text