### PR TITLE
Mover de calcular cuenta de origen logica en un metodo para poder sobreescrivirlo

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -849,6 +849,25 @@ class poweremail_templates(osv.osv):
                                context)
         return True
 
+    def get_from_account_id_from_template(self, cursor, uid, template_id, context=None):
+        if context is None:
+            context = {}
+        if isinstance(template_id, (list, tuple)):
+            template_id = template_id[0]
+
+        if 'account_id' in context:
+            from_account = self.pool.get('poweremail.core_accounts').read(
+                cursor, uid, context.get('account_id'), ['name', 'email_id'], context=context
+            )
+        else:
+            template = self.browse(cursor, uid, template_id, context=context)
+            from_account = {
+                'id': template.enforce_from_account.id,
+                'name': template.enforce_from_account.name,
+                'email_id': template.enforce_from_account.email_id
+            }
+        return from_account
+
     def _generate_mailbox_item_from_template(self,
                                       cursor,
                                       user,
@@ -870,21 +889,8 @@ class poweremail_templates(osv.osv):
         """
         if context is None:
             context = {}
-        #If account to send from is in context select it, else use enforced account
-        if 'account_id' in context.keys():
-            from_account = self.pool.get('poweremail.core_accounts').read(
-                                                    cursor,
-                                                    user,
-                                                    context.get('account_id'),
-                                                    ['name', 'email_id'],
-                                                    context
-                                                    )
-        else:
-            from_account = {
-                            'id':template.enforce_from_account.id,
-                            'name':template.enforce_from_account.name,
-                            'email_id':template.enforce_from_account.email_id
-                            }
+        from_account = self.get_from_account_id_from_template(cursor, user, template.id, context=context)
+
         lang = get_value(cursor,
                          user,
                          record_id,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,12 +4,12 @@ from destral import testing
 
 class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
 
-    def create_account(self):
+    def create_account(self, extra_vals=None):
         acc_obj = self.openerp.pool.get('poweremail.core_accounts')
         cursor = self.cursor
         uid = self.uid
 
-        acc_id = acc_obj.create(cursor, uid, {
+        vals = {
             'name': 'Test account',
             'user': self.uid,
             'email_id': 'test@example.com',
@@ -18,10 +18,14 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
             'smtpuname': 'test',
             'smtppass': 'test',
             'company': 'yes'
-        })
+        }
+        if extra_vals:
+            vals.update(extra_vals)
+
+        acc_id = acc_obj.create(cursor, uid, vals)
         return acc_id
 
-    def create_template(self):
+    def create_template(self, extra_vals=None):
 
         imd_obj = self.openerp.pool.get('ir.model.data')
         tmpl_obj = self.openerp.pool.get('poweremail.templates')
@@ -33,13 +37,17 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
             cursor, uid, 'base', 'model_res_partner'
         )[1]
 
-        tmpl_id = tmpl_obj.create(cursor, uid, {
+        vals = {
             'name': 'Test template',
             'object_name': model_partner,
             'enforce_from_account': acc_id,
             'template_language': 'mako',
             'def_priority': '2'
-        })
+        }
+        if extra_vals:
+            vals.update(extra_vals)
+
+        tmpl_id = tmpl_obj.create(cursor, uid, vals)
         return tmpl_id
 
     def test_creating_email_gets_default_priority(self):


### PR DESCRIPTION
Como dice la descripcion, se mmueve la lógica sin hacer nada nuevo. Solo se uece para que el método pueda ser sobreescrito por otros módulos.