### PR TITLE
Pass poweremail mailbox ID

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -187,7 +187,10 @@ class PoweremailMailbox(osv.osv):
                         _('Error'),
                         _("The email must have a sending account.")
                     )
-
+                if ctx.get("extra_vals_to_read"):
+                    if not ctx.get('extra_vals'):
+                        ctx['extra_vals'] = {}
+                    ctx['extra_vals'].update(self.read(cr, uid, id, ctx.get("extra_vals_to_read")))
                 result = core_obj.send_mail(
                     cr, uid, [values['pem_account_id'][0]], {
                         'To': values['pem_to'],

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -171,6 +171,7 @@ class PoweremailMailbox(osv.osv):
                         headers['In-Reply-To'] = mails[-1].pem_message_id
                 ctx = context.copy()
                 ctx.update({'MIME_subtype': values['mail_type'] or False})
+                ctx['poweremail_id'] = id
                 if not values.get('pem_body_html') and not values.get('pem_body_text'):
                     raise osv.except_osv(
                         _('Error'),

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -187,10 +187,11 @@ class PoweremailMailbox(osv.osv):
                         _('Error'),
                         _("The email must have a sending account.")
                     )
-                if ctx.get("extra_vals_to_read"):
-                    if not ctx.get('extra_vals'):
-                        ctx['extra_vals'] = {}
-                    ctx['extra_vals'].update(self.read(cr, uid, id, ctx.get("extra_vals_to_read")))
+
+                if ctx.get("poweremail_mailbox_fields"):
+                    for val_to_read in ctx.get("poweremail_mailbox_fields"):
+                        ctx[val_to_read] = self.read(cr, uid, id, [val_to_read])[val_to_read]
+
                 result = core_obj.send_mail(
                     cr, uid, [values['pem_account_id'][0]], {
                         'To': values['pem_to'],

--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -305,6 +305,7 @@ class poweremail_send_wizard(osv.osv_memory):
                 'state':'na',
                 'mail_type':'multipart/alternative' #Options:'multipart/mixed','multipart/alternative','text/plain','text/html'
             }
+            vals.update(context.get("extra_vals", {}))
             if screen_vals['signature']:
                 signature = self.pool.get('res.users').read(cr, uid, uid, ['signature'], context)['signature']
                 if signature:

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -959,6 +959,7 @@ class poweremail_templates(osv.osv):
                     mailbox_values['pem_body_text'] += "\n--\n"+sign
                 if mailbox_values['pem_body_html']:
                     mailbox_values['pem_body_html'] += sign
+        mailbox_values.update(context.get("extra_vals", {}))
         mailbox_id = self.pool.get('poweremail.mailbox').create(
                                                              cursor,
                                                              user,


### PR DESCRIPTION
- Se passa por context el ID del `poweremail.mailbox` desde la que se han obtenido los datos utilizados para enviar el email a través del método `send_mail` del objeto `poweremail.core_account`. De este modo, una vez enviado un email se puede realizar alguna acción sobre el `poweremail.mailbox`

- Se añade un nuevo parametro en el context `extra_vals_to_read` a través del cual se indica la información extra a leer del `poweremail.mailbox` que se esté enviando para enviarla al método `send_mail` del objeto `poweremail.core_account`. De este modo otros módulos pueden añadir nuevos campos a leer y recibir en el método `send_mail`