### PR TITLE
IMP Ensures id list on generate_mail function

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -974,6 +974,8 @@ class poweremail_templates(osv.osv):
                       context=None):
         if context is None:
             context = {}
+        if not isinstance(record_ids, (list, tuple)):
+            record_ids = [record_ids]
         template = self.browse(cursor, user, template_id, context=context)
         if not template:
             raise Exception("The requested template could not be loaded")


### PR DESCRIPTION
We ensure that **record_ids** is a list to avoid an error