### PR TITLE
Blacklist recipients

### DIFF
--- a/__terp__.py
+++ b/__terp__.py
@@ -57,6 +57,7 @@
         'poweremail_template_view.xml',
         'poweremail_send_wizard.xml',
         'poweremail_mailbox_view.xml',
+        'poweremail_data.xml',
         'poweremail_serveraction_view.xml'
     ],
     "installable": True,

--- a/poweremail_data.xml
+++ b/poweremail_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record model="res.config" id="poweremail_recipients_blacklist">
+            <field name="name">poweremail_recipients_blacklist</field>
+            <field name="value">[]</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Nueva variable de configuración: `poweremail_recipients_blacklist` que permite indicar los destinatarios a los cuales no se les debe enviar correos electrónicos al estar en una lista negra _blacklist_