### PR TITLE
Move failed to send emails to an Error folder

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -68,6 +68,16 @@ class PoweremailMailbox(osv.osv):
                                  netsvc.LOG_ERROR,
                                  _("Error sending mail: %s") % str(e))
 
+    def _folder_selection(self, cursor, uid, context=None):
+        return [
+            ('inbox', 'Inbox'),
+            ('drafts', 'Drafts'),
+            ('outbox', 'Outbox'),
+            ('trash', 'Trash'),
+            ('followup', 'Follow Up'),
+            ('sent', 'Sent Items'),
+            ('error', 'Error')
+        ]
 
     def get_all_mail(self, cr, uid, context=None):
         if context is None:
@@ -208,6 +218,10 @@ class PoweremailMailbox(osv.osv):
                     self.write(cr, uid, id, {'folder':'sent', 'state':'na', 'date_mail':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
                     self.historise(cr, uid, [id], _("Email sent successfully"), context)
                 else:
+                    self.write(
+                        cr, uid, id, {'folder': 'error', 'state': 'na'},
+                        context=context
+                    )
                     self.historise(cr, uid, [id], result, context, error=True)
             except Exception as exc:
                 error = traceback.format_exc()
@@ -423,14 +437,7 @@ class PoweremailMailbox(osv.osv):
                             ], 'Mail Contents'),
             #I like GMAIL which allows putting same mail in many folders
             #Lets plan it for 0.9
-            'folder':fields.selection([
-                            ('inbox', 'Inbox'),
-                            ('drafts', 'Drafts'),
-                            ('outbox', 'Outbox'),
-                            ('trash', 'Trash'),
-                            ('followup', 'Follow Up'),
-                            ('sent', 'Sent Items'),
-                            ], 'Folder', required=True),
+            'folder':fields.selection(_folder_selection, 'Folder', required=True),
             'state':fields.selection([
                             ('read', 'Read'),
                             ('unread', 'Un-Read'),

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -218,10 +218,6 @@ class PoweremailMailbox(osv.osv):
                     self.write(cr, uid, id, {'folder':'sent', 'state':'na', 'date_mail':time.strftime("%Y-%m-%d %H:%M:%S")}, context)
                     self.historise(cr, uid, [id], _("Email sent successfully"), context)
                 else:
-                    self.write(
-                        cr, uid, id, {'folder': 'error', 'state': 'na'},
-                        context=context
-                    )
                     self.historise(cr, uid, [id], result, context, error=True)
             except Exception as exc:
                 error = traceback.format_exc()
@@ -307,9 +303,10 @@ class PoweremailMailbox(osv.osv):
             history_newline = "\n{}: {}".format(
                 time.strftime("%Y-%m-%d %H:%M:%S"), tools.ustr(message)
             )
-            self.write(
-                cr, uid, pmail_id, {
-                    'history': (history or '') + history_newline}, context)
+            mailbox_wv = {'history': (history or '') + history_newline}
+            if error:
+                mailbox_wv.update({'folder': 'error', 'state': 'na'})
+            self.write(cr, uid, pmail_id, mailbox_wv, context=context)
 
     def complete_mail(self, cr, uid, ids, context=None):
         if context is None:

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -200,6 +200,23 @@
 				</tree>
 			</field>
 		</record>
+		<!--ERROR-->
+		<record model="ir.ui.view" id="poweremail_errorbox_tree">
+			<field name="name">poweremail.mailbox.trashboxtree</field>
+			<field name="model">poweremail.mailbox</field>
+			<field name="type">tree</field>
+			<field name="arch" type="xml">
+				<tree string="Power Email Error">
+					<field name="pem_user" />
+					<field name="pem_from" select="1" />
+					<field name="pem_to" select="1" />
+					<field name="pem_subject" select="1" />
+					<field name="pem_attachments_ids" select="2" />
+					<field name="date_mail" select="2" />
+					<field name="pem_recd" colspan="2" />
+				</tree>
+			</field>
+		</record>
 		<!--8888888888888888888888888888888888 ACTIONS 8888888888888888888888888888888888888888-->
 		<record model="ir.actions.act_window" id="action_poweremail_conversation_tree">
 			<field name="name">Email Mailbox Conversation</field>
@@ -323,6 +340,16 @@
 			<field name="domain">[('folder','=','trash')]</field>
 			<field name="context">{'company':True}</field>
 		</record>
+		<!--TRASH-->
+		<record model="ir.actions.act_window" id="action_poweremail_error_tree_company">
+			<field name="name">Email Mailbox</field>
+			<field name="res_model">poweremail.mailbox</field>
+			<field name="view_type">form</field>
+			<field name="view_mode">form,tree</field>
+			<field name="view_id" ref="poweremail_errorbox_tree" />
+			<field name="domain">[('folder', '=', 'error')]</field>
+			<field name="context">{'company':True}</field>
+		</record>
 		<!--8888888888888888888888888888888888 MENUS 8888888888888888888888888888888888888888-->
 		<menuitem name="MailBox" id="menu_poweremail_mailbox_all_main2" parent="menu_poweremail_administration_server" />
 		<menuitem name="Personal" id="menu_poweremail_personal" parent="menu_poweremail_mailbox_all_main2" />
@@ -341,6 +368,7 @@
 		<menuitem name="Follow-up" id="menu_poweremail_follow_company" parent="menu_poweremail_company" action="action_poweremail_follow_tree_company" />
 		<menuitem name="Sent" id="menu_poweremail_sent_company" parent="menu_poweremail_company" action="action_poweremail_sent_tree_company" />
 		<menuitem name="Trash" id="menu_poweremail_trash_company" parent="menu_poweremail_company" action="action_poweremail_trash_tree_company" />
+		<menuitem name="Error" id="menu_poweremail_error_company" parent="menu_poweremail_company" action="action_poweremail_error_tree_company" />
 
 	</data>
 </openerp>


### PR DESCRIPTION
Si el envío del correo falla, entonces se mueve a una nueva carpeta: "Error" para evitar el reenvio constante de correos que no se han podido enviar.