### PR TITLE
FIX: Avoid starting comma in the email string when the original email string ends with comma

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -50,7 +50,7 @@ from html2text import html2text
 def filter_send_emails(emails_str):
     if not emails_str:
         emails_str = ''
-    return ', '.join(set([e.strip() for e in emails_str.split(',')]))
+    return ', '.join(set([e.strip() for e in emails_str.split(',') if e.strip()]))
 
 _priority_selection = [('0', 'Low'),
                        ('1', 'Normal'),


### PR DESCRIPTION
When the original string of emails for the `def_to`, `def_cc` or `def_bcc` fields ends with a `,`, the generated string of emails had a starting `,`. The resulting string was considered invalid so the email was directed to the `drafts` folder. 

With this change, we avoid this starting `,` so the generated string is not invalid.