### PR TITLE
Poder configurar el nombre màxim d'emails per enviar d'un sol cop

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -117,6 +117,15 @@ class PoweremailMailbox(osv.osv):
             for each_filter in context['filters']:
                 filters.append(each_filter)
         limit = context.get('limit', None)
+
+        if limit is None:
+            varconf_o = self.pool.get('res.config')
+            poweremail_n_mails_per_batch = int(varconf_o.get(
+                cr, uid, 'poweremail_n_mails_per_batch', '0'
+            ))
+            if poweremail_n_mails_per_batch:
+                limit = poweremail_n_mails_per_batch
+
         order = "priority desc, date_mail desc"
         ids = self.search(cr, uid, filters,
                           limit=limit, order=order,

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -106,6 +106,8 @@ class PoweremailMailbox(osv.osv):
             raise osv.except_osv(_("Mail fetch exception"), _("No information on which mail should be fetched fully"))
 
     def _get_mails_to_send(self, cursor, uid, context=None):
+        if context is None:
+            context = {}
         filters = [('folder', '=', 'outbox'), ('state', '!=', 'sending')]
         if 'filters' in context.keys():
             for each_filter in context['filters']:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from destral import testing
+from destral.transaction import Transaction
 
 
 class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
@@ -94,3 +95,81 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
         })
         wiz = send_obj.browse(cursor, uid, wiz_id)
         self.assertEqual(wiz.priority, '2')
+
+
+class TestPoweremailMailbox(testing.OOTestCase):
+
+    def create_account(self, cursor, uid, extra_vals=None):
+        acc_obj = self.openerp.pool.get('poweremail.core_accounts')
+
+        vals = {
+            'name': 'Test account',
+            'user': uid,
+            'email_id': 'test@example.com',
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'smtpuname': 'test',
+            'smtppass': 'test',
+            'company': 'yes'
+        }
+        if extra_vals:
+            vals.update(extra_vals)
+
+        acc_id = acc_obj.create(cursor, uid, vals)
+        return acc_id
+
+    def create_template(self, cursor, uid, extra_vals=None):
+
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        tmpl_obj = self.openerp.pool.get('poweremail.templates')
+        acc_id = self.create_account(cursor, uid)
+
+        model_partner = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'model_res_partner'
+        )[1]
+
+        vals = {
+            'name': 'Test template',
+            'object_name': model_partner,
+            'enforce_from_account': acc_id,
+            'template_language': 'mako',
+            'def_priority': '2'
+        }
+        if extra_vals:
+            vals.update(extra_vals)
+
+        tmpl_id = tmpl_obj.create(cursor, uid, vals)
+        return tmpl_id
+
+    def test_poweremail_n_mails_per_batch(self, extra_vals=None):
+        self.openerp.install_module('base_extended')
+
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mail_o = self.openerp.pool.get('poweremail.mailbox')
+            varconf_o = self.openerp.pool.get('res.config')
+            imd_obj = self.openerp.pool.get('ir.model.data')
+            tmpl_id = self.create_template(cursor, uid)
+            tmpl_obj = self.openerp.pool.get('poweremail.templates')
+
+            partner_id = imd_obj.get_object_reference(
+                cursor, uid, 'base', 'res_partner_asus'
+            )[1]
+            template = tmpl_obj.browse(cursor, uid, tmpl_id)
+            for i in range(3):
+                mail_id = tmpl_obj._generate_mailbox_item_from_template(
+                    cursor, uid, template, partner_id
+                )
+                mail_wv = {'folder': 'outbox', 'state': 'na'}
+                mail_o.write(cursor, uid, mail_id, mail_wv)
+
+            varconf_o.set(cursor, uid, 'poweremail_n_mails_per_batch', 1)
+            mails_per_enviar = mail_o._get_mails_to_send(cursor, uid)
+            self.assertEqual(len(mails_per_enviar), 1)
+            mails_per_enviar = mail_o._get_mails_to_send(cursor, uid, context={'limit': 2})
+            self.assertEqual(len(mails_per_enviar), 2)
+
+            varconf_o.set(cursor, uid, 'poweremail_n_mails_per_batch', 0)
+            mails_per_enviar = mail_o._get_mails_to_send(cursor, uid)
+            self.assertEqual(len(mails_per_enviar), 3)


### PR DESCRIPTION
## Variable de configuración

- `poweremail_n_mails_per_batch`: indica la quantitat d'emails que es poden enviar d'un sol cop.
    - Valors possibles: enters.
    - El valor `0` indica `Sense limit`. 
    - Té prioritat el `limit` que es passa per `context`.
- `poweremail_n_mails_per_batch_per_account`: indica la quantitat d'emails que es poden enviar d'un sol cop per compte de correu.
    -  Valor possible: diccionari on la clau es el nom del compte de correu (string) i el valor es el limit (enter > 0)
    - Els comptes de correu que no estiguin al diccionari no s'els aplicarà limit

`poweremail_n_mails_per_batch` té prioritat per sobre de `poweremail_n_mails_per_batch_per_account`