### PR TITLE
Remove unnecessary encode

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -275,7 +275,7 @@ class poweremail_core_accounts(osv.osv):
                     if serv.has_extn('AUTH'):
                         if this_object.smtpuname or this_object.smtppass:
                             serv.login(this_object.smtpuname,
-                                       this_object.smtppass.encode('ascii'))
+                                       this_object.smtppass)
                 except Exception as error:
                     raise error
                 return serv


### PR DESCRIPTION
No entinedo la necesidad de codificar la contraseña. Podemos probar esto en un servidor de 🔬 PRE y decidir si lo eliminamos? Si no quitamos esto, con py3 no funciona

## Related

- TASK-88225