### PR TITLE
Nuevas vistas para plantillas con formato basico del poweremail

### DIFF
--- a/__terp__.py
+++ b/__terp__.py
@@ -57,14 +57,14 @@
         'security/ir.model.access.csv',
         'poweremail_workflow.xml',
         'poweremail_core_view.xml',
+        'wizard/wizard_generate_test_email.xml',
         'poweremail_template_view.xml',
         'poweremail_send_wizard.xml',
         'poweremail_mailbox_view.xml',
         'poweremail_serveraction_view.xml',
         'wizard/wizard_state_poweremail.xml',
         'wizard/wizard_send_email.xml',
-        'wizard/wizard_poweremail.xml',
-        'wizard/wizard_generate_test_email.xml'
+        'wizard/wizard_poweremail.xml'
     ],
     "installable": True,
     "active": False,

--- a/__terp__.py
+++ b/__terp__.py
@@ -64,6 +64,7 @@
         'wizard/wizard_state_poweremail.xml',
         'wizard/wizard_send_email.xml',
         'wizard/wizard_poweremail.xml',
+        'wizard/wizard_generate_test_email.xml'
     ],
     "installable": True,
     "active": False,

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -293,5 +293,83 @@
 
         <menuitem name="Email Templates" id="menu_poweremail_templates_all"
             parent="menu_poweremail_templates" action="action_poweremail_template_tree_all" />
+
+        <!--EMail Basic client Form view  -->
+        <record model="ir.ui.view" id="poweremail_basic_template_form">
+            <field name="name">poweremail.basic.templates.form</field>
+            <field name="model">poweremail.templates</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Power Email Templates">
+                    <field name="name" />
+                    <field name="object_name" required="1"/>
+                    <field name="model_int_name" invisible="1" />
+                    <notebook colspan="4">
+                        <page string="Mail Details">
+                            <group col="4" colspan="2">
+                                <field name="def_to" colspan="4"
+                                    required="1" />
+                                <field name="enforce_from_account"
+                                attrs="{'required':[('auto_email','=',True)]}" />
+                            </group>
+                            <group col="2" colspan="2">
+                                <field name="def_subject" colspan="4"
+                                    required="1" />
+                            </group>
+                            <separator colspan="3" string="Standard Body" />
+                            <separator colspan="1"
+                                string="Template Tester" />
+                            <notebook>
+                                <page string="Body (Text)">
+                                    <field name="def_body_text"
+                                        colspan="4" nolabel="1" />
+                                </page>
+                            </notebook>
+                            <group col="4">
+                            <button icon="gtk-go-forward" name="%(action_wizard_generate_email_form)d"
+                                    string="Generate test mail" type="action" colspan="4"/>
+                            </group>
+                        </page>
+                    </notebook>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="poweremail_basic_template_tree">
+            <field name="name">poweremail.basic.templates.tree</field>
+            <field name="model">poweremail.templates</field>
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                <tree string="Power Email Templates">
+                    <field name="name" select="1" />
+                    <field name="object_name" required="1" select="1" />
+                    <field name="def_to" colspan="4" select="2" />
+                    <field name="use_sign" colspan="4" select="2" />
+                    <field name="def_subject" colspan="4" select="2" />
+                </tree>
+            </field>
+        </record>
+
+        <!--Email Basic Client actions to open basic views  -->
+        <record model="ir.actions.act_window" id="action_poweremail_basic_template_all">
+            <field name="name">Email Basic Templates</field>
+            <field name="res_model">poweremail.templates</field>
+        </record>
+
+        <record model="ir.actions.act_window.view" id="action_poweremail_basic_template_tree_all">
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="poweremail_basic_template_tree"/>
+            <field name="act_window_id" ref="action_poweremail_basic_template_all"/>
+        </record>
+
+        <record model="ir.actions.act_window.view" id="action_poweremail_basic_template_form_all">
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="poweremail_basic_template_form"/>
+            <field name="act_window_id" ref="action_poweremail_basic_template_all"/>
+        </record>
+
+        <menuitem name="Email Basic Templates" id="menu_poweremail_basic_templates_all"
+            parent="menu_poweremail_templates" action="action_poweremail_basic_template_all" />
+
     </data>
 </openerp>

--- a/wizard/__init__.py
+++ b/wizard/__init__.py
@@ -1,3 +1,4 @@
 import wizard_state_poweremail
 import wizard_send_email
 import wizard_poweremail
+import wizard_generate_test_email

--- a/wizard/wizard_generate_test_email.py
+++ b/wizard/wizard_generate_test_email.py
@@ -3,7 +3,7 @@
 from osv import osv, fields
 from tools.translate import _
 import tools
-
+from poweremail.poweremail_template import get_value
 
 class WizardGenerateTestEmail(osv.osv_memory):
 
@@ -19,6 +19,15 @@ class WizardGenerateTestEmail(osv.osv_memory):
         wizard = self.browse(cursor, uid, ids[0], context=context)
         template_ids = context['active_ids']
 
+        if not wizard.model_ref:
+            raise osv.except_osv(
+                _('Error'),
+                _('No model reference defined')
+            )
+        model_ref = wizard.model_ref.split(',')
+        model_name = model_ref[0]
+        model_id = int(model_ref[1])
+
         if not isinstance(template_ids, (list, tuple)):
             template_ids = [template_ids]
 
@@ -32,6 +41,16 @@ class WizardGenerateTestEmail(osv.osv_memory):
                 cursor, uid, template.id, context=context
             )
 
+            # Evaluates an expression and returns its value
+            # recid: ID of the target record under evaluation
+            # message: The expression to be evaluated
+            # template: BrowseRecord object of the current template
+            # return: Computed message (unicode) or u""
+            body_text = get_value(
+                cursor, uid, model_id, message=template.def_body_text,
+                template=template, context=context
+            )
+
             mail_vals = {
                 'pem_from': tools.ustr(from_account['name']) + \
                             "<" + tools.ustr(from_account['email_id']) + ">",
@@ -39,7 +58,7 @@ class WizardGenerateTestEmail(osv.osv_memory):
                 'pem_cc': False,
                 'pem_bcc': False,
                 'pem_subject': template.name,
-                'pem_body_text': template.def_body_text,
+                'pem_body_text': body_text,
                 'pem_account_id': from_account['id'],
                 'priority': '1',
                 'state': 'na',
@@ -59,9 +78,31 @@ class WizardGenerateTestEmail(osv.osv_memory):
             'res_model': 'poweremail.mailbox',
             'type': 'ir.actions.act_window'
         }
+
+    def _ref_models(self, cursor, uid, context=None):
+        template_obj = self.pool.get('poweremail.templates')
+
+        if not context:
+            context = {}
+
+        template_ids = context['active_ids']
+
+        if not isinstance(template_ids, (list, tuple)):
+            template_ids = [template_ids]
+        res = []
+        for template in template_obj.browse(cursor, uid, template_ids, context=context):
+            template_model = template.object_name.model
+            template_name = template.object_name.name
+            res.append((template_model, template_name))
+
+        return res
     
     _columns = {
         'state': fields.selection([('init', 'Init'), ('end', 'End')], 'State'),
+        'model_ref': fields.reference(
+            "Template reference", selection=_ref_models,
+            size=64, required=True
+        ),
     }
 
     _defaults = {

--- a/wizard/wizard_generate_test_email.py
+++ b/wizard/wizard_generate_test_email.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from osv import osv, fields
+from tools.translate import _
+import tools
+
+
+class WizardGenerateTestEmail(osv.osv_memory):
+
+    _name = 'wizard.generate.test.email'
+
+    def action_generate_static_mail(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+            
+        template_obj = self.pool.get('poweremail.templates')
+        mailbox_obj = self.pool.get('poweremail.mailbox')
+
+        wizard = self.browse(cursor, uid, ids[0], context=context)
+        template_ids = context['active_ids']
+
+        if not isinstance(template_ids, (list, tuple)):
+            template_ids = [template_ids]
+
+        mailbox_ids = []
+        for template_id in template_ids:
+            template = template_obj.browse(cursor, uid, template_id, context=context)
+            if not template:
+                raise Exception("The requested template could not be loaded")
+
+            from_account = template_obj.get_from_account_id_from_template(
+                cursor, uid, template.id, context=context
+            )
+
+            mail_vals = {
+                'pem_from': tools.ustr(from_account['name']) + \
+                            "<" + tools.ustr(from_account['email_id']) + ">",
+                'pem_to': template.def_to,
+                'pem_cc': False,
+                'pem_bcc': False,
+                'pem_subject': template.name,
+                'pem_body_text': template.def_body_text,
+                'pem_account_id': from_account['id'],
+                'priority': '1',
+                'state': 'na',
+                'mail_type': 'multipart/alternative'
+            }
+
+            mailbox_id = mailbox_obj.create(cursor, uid, mail_vals)
+            mailbox_ids.append(mailbox_id)
+
+        wizard.write({'state': 'end'}, context=context)
+
+        return {
+            'domain': "[('id','in', %s)]" % str(mailbox_ids),
+            'name': _('Generated Email'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'poweremail.mailbox',
+            'type': 'ir.actions.act_window'
+        }
+    
+    _columns = {
+        'state': fields.selection([('init', 'Init'), ('end', 'End')], 'State'),
+    }
+
+    _defaults = {
+        'state': lambda *a: 'init',
+    }
+
+
+
+WizardGenerateTestEmail()

--- a/wizard/wizard_generate_test_email.xml
+++ b/wizard/wizard_generate_test_email.xml
@@ -29,6 +29,9 @@
 	        	<form string="Enviar emails">
 	        		<field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state','!=','init')]}">
+						<group colspan="4" col="2">
+							<field name="mode_ref"/>
+						</group>
 		        		<group colspan="4" col="2">
 		        			<button icon="gtk-close" special="cancel" string="Cancel" type="object"/>
 		        			<button name="action_generate_static_mail"

--- a/wizard/wizard_generate_test_email.xml
+++ b/wizard/wizard_generate_test_email.xml
@@ -30,7 +30,7 @@
 	        		<field name="state" invisible="1"/>
                     <group attrs="{'invisible': [('state','!=','init')]}">
 						<group colspan="4" col="2">
-							<field name="mode_ref"/>
+							<field name="model_ref"/>
 						</group>
 		        		<group colspan="4" col="2">
 		        			<button icon="gtk-close" special="cancel" string="Cancel" type="object"/>

--- a/wizard/wizard_generate_test_email.xml
+++ b/wizard/wizard_generate_test_email.xml
@@ -1,0 +1,47 @@
+
+<openerp>
+	<data>
+        <record id="action_wizard_generate_email_form" model="ir.actions.act_window">
+            <field name="name">Generate Email test</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.generate.test.email</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+        <record id="value_wizard_generate_email_form" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Generate Email test</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">poweremail.templates</field>
+            <field name="value"
+                   eval="'ir.actions.act_window,'+str(ref('action_wizard_generate_email_form'))" />
+        </record>
+
+        <!--Finestra de dins de l'assistent-->
+        <record id="view_wizard_send_email_form" model="ir.ui.view">
+	    	<field name="name">wizard.generate.test.email.form</field>
+	      	<field name="model">wizard.generate.test.email</field>
+	      	<field name="type">form</field>
+	      	<field name="arch" type="xml">
+	        	<form string="Enviar emails">
+	        		<field name="state" invisible="1"/>
+                    <group attrs="{'invisible': [('state','!=','init')]}">
+		        		<group colspan="4" col="2">
+		        			<button icon="gtk-close" special="cancel" string="Cancel" type="object"/>
+		        			<button name="action_generate_static_mail"
+                                    icon="gtk-ok" string="Generate Email" type="object"/>
+		        		</group>
+		        	</group>
+		        	<group attrs="{'invisible': [('state','!=','end')]}">
+		        		<label string="Email done!" colspan="4"/>
+		        		<newline/>
+		        		<button icon="gtk-close" special="cancel" string="Close" type="object" colspan="4"/>
+		        	</group>
+		        </form>
+	        </field>
+	    </record>
+	</data>
+</openerp>


### PR DESCRIPTION
## Objetivos

- Crear una plantilla simplificada
- Crear un botón para generar emails de prueba

![generate demo poweremail](https://user-images.githubusercontent.com/83698096/188656013-f667fbc9-d42d-40f7-a1aa-b96cce558d84.gif)


## Comportamiento nuevo

- Se crea un nuevo menú para plantillas con las vistas simplificadas
- Se crea un nuevo asistente para generar correos de prueba

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [x] Actualización módulos:
    - poweremail

## Checklist

- [x] Test code
