### PR TITLE
Force password as string so unexpected characters do not raise and error

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -562,7 +562,7 @@ class poweremail_core_accounts(osv.osv):
                 host=account.smtpserver,
                 port=account.smtpport,
                 user=account.smtpuname,
-                passwd=account.smtppass,
+                passwd=str(account.smtppass),
                 tls=account.smtptls,
                 ssl=account.smtpssl
             ):


### PR DESCRIPTION
Sometimes when the password has special characters an error is raised by hmac library which does not expect the incoming password.
The error in question is the following one:

```
  File "/home/erp/src/erp/server/bin/addons/poweremail/poweremail_mailbox.py", line 241, in send_this_mail
    }, payload=payload, context=ctx
  File "/home/erp/src/erp/server/bin/addons/poweremail/poweremail_core.py", line 567, in send_mail
    ssl=account.smtpssl
  File "/home/erp/local/lib/python2.7/site-packages/qreu/sendcontext.py", line 112, in __enter__
    self._connection.login(user=self._user, password=self._passwd)
  File "/usr/lib/python2.7/smtplib.py", line 608, in login
    (code, resp) = self.docmd(encode_cram_md5(resp, user, password))
  File "/usr/lib/python2.7/smtplib.py", line 572, in encode_cram_md5
    response = user + " " + hmac.HMAC(password, challenge).hexdigest()
  File "/usr/lib/python2.7/hmac.py", line 75, in __init__
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode
```
In this PR I force the password as a string so now the password is correct. Maybe there are other or better solutions, but this just fix the bug atm.
