### PR TITLE
Improve the email validation behaviour

### DIFF
--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -364,7 +364,10 @@ class PoweremailMailbox(osv.osv):
         if not email:
             return False
 
-        emails = email.split(',')
+        emails = []
+        for mail in email.split(','):
+            emails += mail.split(';')
+
         if len(emails)>0:
             for email in emails:
                 if not get_validate_email(email.strip()):

--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -238,7 +238,11 @@ class poweremail_send_wizard(osv.osv_memory):
         if mail_ids:
             for mail_id in mail_ids:
                 if not mailbox_obj.is_valid(cr, uid, mail_id):
-                    values['folder'] = 'drafts'
+                    values['folder'] = 'error'
+                    mailbox_v = mailbox_obj.read(cr, uid, mail_id, ['history'], context=context)
+                    values['history'] = '{}\n{}'.format(
+                        _(u'Not valid destiny email'), mailbox_v['history']
+                    )
                 else:
                     values['folder'] = folder
                 mailbox_obj.write(cr, uid, [mail_id], values, context)

--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -241,7 +241,7 @@ class poweremail_send_wizard(osv.osv_memory):
                     values['folder'] = 'error'
                     mailbox_v = mailbox_obj.read(cr, uid, mail_id, ['history'], context=context)
                     values['history'] = '{}\n{}'.format(
-                        _(u'Not valid destiny email'), mailbox_v['history']
+                        _(u'Not valid destiny email'), mailbox_v['history'] or ''
                     )
                 else:
                     values['folder'] = folder


### PR DESCRIPTION
- Consider semicolon as a valid email separator
- If it is not a valid email, then move to the 'Error' folder instead of the 'Draft' folder