### PR TITLE
Mostrar todos los emails

### DIFF
--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2023-05-16 12:34\n"
-"PO-Revision-Date: 2023-05-16 14:35+0000\n"
-"Last-Translator: lcbautista <>\n"
+"POT-Creation-Date: 2023-06-28 14:35\n"
+"PO-Revision-Date: 2023-06-28 12:48+0000\n"
+"Last-Translator: destanyol <>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -265,10 +265,9 @@ msgid "Server Information"
 msgstr "Informació del servidor"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:728
-#, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
-msgstr "Guardant capçalera de càrrega desconeguda (%s). Compte: %s."
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
+msgstr "Nº de correus generats"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_core.py:341
@@ -312,11 +311,6 @@ msgstr "Converses"
 #: field:poweremail.mailbox,mail_type:0
 msgid "Mail Contents"
 msgstr "Contingut del correu electrònic"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
-msgstr "Correu original"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_send_wizard.py:339
@@ -429,6 +423,12 @@ msgid "Copy of template "
 msgstr "Copia de la plantilla"
 
 #. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr "Tots els correus"
+
+#. module: poweremail
 #: view:poweremail.send.wizard:0
 msgid "Discard Mail"
 msgstr "Cancel·la"
@@ -520,6 +520,7 @@ msgstr "Adjunt de correu per la relació %s correcte! Compte: %s."
 #: field:poweremail.preview,rel_model:0
 #: field:poweremail.send.wizard,rel_model:0
 #: field:poweremail.templates,object_name:0
+#: field:wizard.emails.generats.model,reference:0
 msgid "Model"
 msgstr "Model"
 
@@ -776,6 +777,11 @@ msgstr "No s'ha definit el nom de l'usuari del servidor d'entrada"
 #: selection:wizard.send.email,state:0
 msgid "End"
 msgstr "Fi"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
+msgstr "Buscar correus"
 
 #. module: poweremail
 #: help:poweremail.templates,send_on_write:0
@@ -1040,9 +1046,9 @@ msgid "Mail fetch exception"
 msgstr "Excepció d'extracció de correu"
 
 #. module: poweremail
-#: field:wizard.generate.test.email,model_ref:0
-msgid "Template reference"
-msgstr "Plantilla"
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
+msgstr "Introduïu el port, per exemple per SMTP 587."
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_template.py:1064
@@ -1089,11 +1095,9 @@ msgid "Trash"
 msgstr "Paperera"
 
 #. module: poweremail
-#: help:poweremail.templates,save_to_drafts:0
-msgid ""
-"When automatically sending emails generated from this template, save them "
-"into the Drafts folder rather than sending them immediately."
-msgstr "Quan s'envien correus electrònics generats automàticament a partir d'aquesta plantilla, es desen a la carpeta Esborranys en comptes d'enviar-los immediatament."
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
+msgstr "Buscar correus relacionats"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_core.py:1237
@@ -1266,9 +1270,14 @@ msgid "Power Email Preview"
 msgstr "Previsualització"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
-msgstr "No descarrega els adjunts automàticament"
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr "Correu original"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
+msgstr ""
 
 #. module: poweremail
 #: help:poweremail.core_accounts,iserver:0
@@ -1296,9 +1305,31 @@ msgid "eg: yourname@yourdomain.com"
 msgstr "Exemple: elvostrenom@elvostredomini.com"
 
 #. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid ""
+"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
+"els adjunts del registre utilitzat per renderitzar el email."
+msgstr "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email All Emails"
+msgstr "Tots els correus"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr "No descarrega els adjunts automàticament"
+
+#. module: poweremail
 #: field:poweremail.core_selfolder,folder:0
 msgid "IMAP Folder"
 msgstr "Carpeta IMAP"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
+msgstr "Llistar correus relacionats"
 
 #. module: poweremail
 #: field:poweremail.core_accounts,isssl:0
@@ -1397,11 +1428,10 @@ msgid "Close"
 msgstr "Tanca"
 
 #. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
-msgid ""
-"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
-"els adjunts del registre utilitzat per renderitzar el email."
-msgstr "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
+msgstr "Bústia: Tots els correus"
 
 #. module: poweremail
 #: view:poweremail.mailbox:0 view:poweremail.templates:0
@@ -1573,9 +1603,9 @@ msgid "Message-Id"
 msgstr "Message-Id"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
-msgstr "Introduïu el port, per exemple per SMTP 587."
+#: field:wizard.generate.test.email,model_ref:0
+msgid "Template reference"
+msgstr "Plantilla"
 
 #. module: poweremail
 #: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
@@ -1633,9 +1663,10 @@ msgid "Generate Email test"
 msgstr "Generar correu de prova"
 
 #. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
-msgstr "Nº de correus generats"
+#: code:addons/poweremail/poweremail_core.py:728
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
+msgstr "Guardant capçalera de càrrega desconeguda (%s). Compte: %s."
 
 #. module: poweremail
 #: help:poweremail.templates,enforce_from_account:0
@@ -1690,6 +1721,13 @@ msgstr "El contingut de l'email no pot estar buit."
 #: view:wizard.send.email:0
 msgid "Endavant"
 msgstr "Endavant"
+
+#. module: poweremail
+#: help:poweremail.templates,save_to_drafts:0
+msgid ""
+"When automatically sending emails generated from this template, save them "
+"into the Drafts folder rather than sending them immediately."
+msgstr "Quan s'envien correus electrònics generats automàticament a partir d'aquesta plantilla, es desen a la carpeta Esborranys en comptes d'enviar-los immediatament."
 
 #. module: poweremail
 #: help:poweremail.templates,partner_event:0
@@ -1956,11 +1994,6 @@ msgid "Select the fields you require in the table."
 msgstr "Seleccioneu els camps que necessiteu a la taula."
 
 #. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
-msgstr "Plantilla Django"
-
-#. module: poweremail
 #: help:poweremail.templates,def_priority:0
 msgid "Default priority for auto generated emails"
 msgstr "Prioritat per defecte pels correus generats automàticament"
@@ -2213,6 +2246,12 @@ msgstr "Plantilla de prova"
 #: help:poweremail.core_accounts,isport:0
 msgid "For example IMAP: 993,POP3:995"
 msgstr "Per exemple IMAP: 993, POP3: 995."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
+msgstr "Buscar Correus Relacionats"
 
 #. module: poweremail
 #: help:poweremail.templates,def_bcc:0

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2023-05-16 12:34\n"
-"PO-Revision-Date: 2023-05-16 14:18+0000\n"
-"Last-Translator: lcbautista <>\n"
+"POT-Creation-Date: 2023-06-28 14:35\n"
+"PO-Revision-Date: 2023-06-28 12:47+0000\n"
+"Last-Translator: destanyol <>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -265,10 +265,9 @@ msgid "Server Information"
 msgstr "Información del servidor"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:728
-#, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
-msgstr "Guardando cabecera de carga desconocida (%s). Cuenta: %s."
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
+msgstr "Nº de correos generados"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_core.py:341
@@ -312,11 +311,6 @@ msgstr "Conversaciones"
 #: field:poweremail.mailbox,mail_type:0
 msgid "Mail Contents"
 msgstr "Contenido del correo electrónico"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
-msgstr "Correo original"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_send_wizard.py:339
@@ -429,6 +423,12 @@ msgid "Copy of template "
 msgstr "Copia de la plantilla"
 
 #. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr "Todos los correos"
+
+#. module: poweremail
 #: view:poweremail.send.wizard:0
 msgid "Discard Mail"
 msgstr "Cancelar"
@@ -520,6 +520,7 @@ msgstr "¡Adjunto de correo para la relación %s correcto! Cuenta: %s."
 #: field:poweremail.preview,rel_model:0
 #: field:poweremail.send.wizard,rel_model:0
 #: field:poweremail.templates,object_name:0
+#: field:wizard.emails.generats.model,reference:0
 msgid "Model"
 msgstr "Modelo"
 
@@ -776,6 +777,11 @@ msgstr "No se ha definido el nombre del usuario del servidor de entrada"
 #: selection:wizard.send.email,state:0
 msgid "End"
 msgstr "Fin"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
+msgstr "Buscar correos"
 
 #. module: poweremail
 #: help:poweremail.templates,send_on_write:0
@@ -1040,9 +1046,9 @@ msgid "Mail fetch exception"
 msgstr "Excepción de extracción de correo"
 
 #. module: poweremail
-#: field:wizard.generate.test.email,model_ref:0
-msgid "Template reference"
-msgstr "Referencia de la plantilla"
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
+msgstr "Introduzca el número del puerto, por ejemplo para SMTP el 587."
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_template.py:1064
@@ -1089,11 +1095,9 @@ msgid "Trash"
 msgstr "Papelera"
 
 #. module: poweremail
-#: help:poweremail.templates,save_to_drafts:0
-msgid ""
-"When automatically sending emails generated from this template, save them "
-"into the Drafts folder rather than sending them immediately."
-msgstr "Cuando se envian correos electrónico generados automáticamentes a partir de esta plantilla, se guardan en la carpeta Borradores en lugar de enviarlos inmediatamente."
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
+msgstr "Buscar correos relacionados"
 
 #. module: poweremail
 #: code:addons/poweremail/poweremail_core.py:1237
@@ -1266,9 +1270,14 @@ msgid "Power Email Preview"
 msgstr "Previsualización"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
-msgstr "No descargar los adjuntos automáticamente"
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr "Correo original"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
+msgstr ""
 
 #. module: poweremail
 #: help:poweremail.core_accounts,iserver:0
@@ -1296,9 +1305,31 @@ msgid "eg: yourname@yourdomain.com"
 msgstr "Ejemplo: sunombre@sudominio.com"
 
 #. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid ""
+"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
+"els adjunts del registre utilitzat per renderitzar el email."
+msgstr "Si se marca esta opción, se enviarán como ficheros adjuntos del correo todos los adjuntos del registro indicado."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email All Emails"
+msgstr "Todos los correos"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr "No descargar los adjuntos automáticamente"
+
+#. module: poweremail
 #: field:poweremail.core_selfolder,folder:0
 msgid "IMAP Folder"
 msgstr "Carpeta IMAP"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
+msgstr "Listar correos relacionados"
 
 #. module: poweremail
 #: field:poweremail.core_accounts,isssl:0
@@ -1397,11 +1428,10 @@ msgid "Close"
 msgstr "Cerrar"
 
 #. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
-msgid ""
-"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
-"els adjunts del registre utilitzat per renderitzar el email."
-msgstr "Si se marca esta opción, se enviarán como ficheros adjuntos del correo todos los adjuntos del registro indicado."
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
+msgstr "Buzón: Todos los correos"
 
 #. module: poweremail
 #: view:poweremail.mailbox:0 view:poweremail.templates:0
@@ -1573,9 +1603,9 @@ msgid "Message-Id"
 msgstr "Message-Id"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
-msgstr "Introduzca el número del puerto, por ejemplo para SMTP el 587."
+#: field:wizard.generate.test.email,model_ref:0
+msgid "Template reference"
+msgstr "Referencia de la plantilla"
 
 #. module: poweremail
 #: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
@@ -1633,9 +1663,10 @@ msgid "Generate Email test"
 msgstr "Generar correo de prueba"
 
 #. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
-msgstr "Nº de correos generados"
+#: code:addons/poweremail/poweremail_core.py:728
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
+msgstr "Guardando cabecera de carga desconocida (%s). Cuenta: %s."
 
 #. module: poweremail
 #: help:poweremail.templates,enforce_from_account:0
@@ -1690,6 +1721,13 @@ msgstr "El contenido del correo no puede estar vacío"
 #: view:wizard.send.email:0
 msgid "Endavant"
 msgstr "Adelante"
+
+#. module: poweremail
+#: help:poweremail.templates,save_to_drafts:0
+msgid ""
+"When automatically sending emails generated from this template, save them "
+"into the Drafts folder rather than sending them immediately."
+msgstr "Cuando se envian correos electrónico generados automáticamentes a partir de esta plantilla, se guardan en la carpeta Borradores en lugar de enviarlos inmediatamente."
 
 #. module: poweremail
 #: help:poweremail.templates,partner_event:0
@@ -1956,11 +1994,6 @@ msgid "Select the fields you require in the table."
 msgstr "Seleccione los campos que necesite en la tabla."
 
 #. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
-msgstr "Plantilla de Django"
-
-#. module: poweremail
 #: help:poweremail.templates,def_priority:0
 msgid "Default priority for auto generated emails"
 msgstr "Prioridad por defecto para los correos generados automáticamente"
@@ -2213,6 +2246,12 @@ msgstr "Plantilla de prueba"
 #: help:poweremail.core_accounts,isport:0
 msgid "For example IMAP: 993,POP3:995"
 msgstr "Por ejemplo IMAP: 993, POP3: 995."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
+msgstr "Buscar Correos Relacionados"
 
 #. module: poweremail
 #: help:poweremail.templates,def_bcc:0

--- a/i18n/poweremail.pot
+++ b/i18n/poweremail.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 5.0.14\n"
 "Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2023-05-16 12:34\n"
-"PO-Revision-Date: 2023-05-16 12:34\n"
+"POT-Creation-Date: 2023-06-28 14:35\n"
+"PO-Revision-Date: 2023-06-28 14:35\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -260,9 +260,8 @@ msgid "Server Information"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:728
-#, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
 msgstr ""
 
 #. module: poweremail
@@ -306,11 +305,6 @@ msgstr ""
 #. module: poweremail
 #: field:poweremail.mailbox,mail_type:0
 msgid "Mail Contents"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
 msgstr ""
 
 #. module: poweremail
@@ -421,6 +415,12 @@ msgid "Copy of template "
 msgstr ""
 
 #. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr ""
+
+#. module: poweremail
 #: view:poweremail.send.wizard:0
 msgid "Discard Mail"
 msgstr ""
@@ -512,6 +512,7 @@ msgstr ""
 #: field:poweremail.preview,rel_model:0
 #: field:poweremail.send.wizard,rel_model:0
 #: field:poweremail.templates,object_name:0
+#: field:wizard.emails.generats.model,reference:0
 msgid "Model"
 msgstr ""
 
@@ -762,6 +763,11 @@ msgstr ""
 #: selection:wizard.generate.test.email,state:0
 #: selection:wizard.send.email,state:0
 msgid "End"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
 msgstr ""
 
 #. module: poweremail
@@ -1022,8 +1028,8 @@ msgid "Mail fetch exception"
 msgstr ""
 
 #. module: poweremail
-#: field:wizard.generate.test.email,model_ref:0
-msgid "Template reference"
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
 msgstr ""
 
 #. module: poweremail
@@ -1071,8 +1077,8 @@ msgid "Trash"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,save_to_drafts:0
-msgid "When automatically sending emails generated from this template, save them into the Drafts folder rather than sending them immediately."
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
 msgstr ""
 
 #. module: poweremail
@@ -1244,8 +1250,13 @@ msgid "Power Email Preview"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
 msgstr ""
 
 #. module: poweremail
@@ -1270,8 +1281,28 @@ msgid "eg: yourname@yourdomain.com"
 msgstr ""
 
 #. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email All Emails"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr ""
+
+#. module: poweremail
 #: field:poweremail.core_selfolder,folder:0
 msgid "IMAP Folder"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
 msgstr ""
 
 #. module: poweremail
@@ -1371,8 +1402,9 @@ msgid "Close"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
-msgid "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
 msgstr ""
 
 #. module: poweremail
@@ -1544,8 +1576,8 @@ msgid "Message-Id"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
+#: field:wizard.generate.test.email,model_ref:0
+msgid "Template reference"
 msgstr ""
 
 #. module: poweremail
@@ -1608,8 +1640,9 @@ msgid "Generate Email test"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
+#: code:addons/poweremail/poweremail_core.py:728
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
 msgstr ""
 
 #. module: poweremail
@@ -1663,6 +1696,11 @@ msgstr ""
 #: view:wizard.change.state.email:0
 #: view:wizard.send.email:0
 msgid "Endavant"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,save_to_drafts:0
+msgid "When automatically sending emails generated from this template, save them into the Drafts folder rather than sending them immediately."
 msgstr ""
 
 #. module: poweremail
@@ -1929,11 +1967,6 @@ msgid "Select the fields you require in the table."
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
-msgstr ""
-
-#. module: poweremail
 #: help:poweremail.templates,def_priority:0
 msgid "Default priority for auto generated emails"
 msgstr ""
@@ -2183,6 +2216,12 @@ msgstr ""
 #. module: poweremail
 #: help:poweremail.core_accounts,isport:0
 msgid "For example IMAP: 993,POP3:995"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
 msgstr ""
 
 #. module: poweremail

--- a/migrations/5.0.23.6.0/post-0002_update_to_see_all_emails.py
+++ b/migrations/5.0.23.6.0/post-0002_update_to_see_all_emails.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info('Adding the menu to see all the emails')
+
+    view = "poweremail_mailbox_view.xml"
+    view_record = [
+        "poweremail_all_emails_tree",
+        "action_poweremail_all_emails_tree",
+        "action_poweremail_all_emails_tree_company",
+    ]
+    logger.info("Updating XML {}".format(view))
+    load_data_records(
+        cursor, 'poweremail', view, view_record, mode='update'
+    )
+    logger.info('XML successfully updated.')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/migrations/5.0.23.6.0/post-0002_update_to_see_all_emails.py
+++ b/migrations/5.0.23.6.0/post-0002_update_to_see_all_emails.py
@@ -16,6 +16,8 @@ def up(cursor, installed_version):
         "poweremail_all_emails_tree",
         "action_poweremail_all_emails_tree",
         "action_poweremail_all_emails_tree_company",
+        "menu_poweremail_all_emails",
+        "menu_poweremail_all_emails_company",
     ]
     logger.info("Updating XML {}".format(view))
     load_data_records(

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -97,6 +97,24 @@
 		</record>
 
 		<!--8888888888888888888888888888888888 TREE VIEWS 8888888888888888888888888888888888888888-->
+		<!--ALL EMAILS-->
+		<record model="ir.ui.view" id="poweremail_all_emails_tree">
+			<field name="name">poweremail.mailbox.allemailstree</field>
+			<field name="model">poweremail.mailbox</field>
+			<field name="type">tree</field>
+			<field name="arch" type="xml">
+				<tree string="Power Email All Emails" colors="blue:state=='unread'">
+					<field name="pem_user" />
+					<field name="pem_from" select="1" />
+					<field name="pem_to" select="1" />
+					<field name="pem_subject" select="1" />
+					<field name="pem_attachments_ids" select="2" />
+					<field name="date_mail" select="2" />
+					<field name="pem_recd" colspan="2" />
+					<field name="state" />
+				</tree>
+			</field>
+		</record>
 		<!--INBOX-->
 		<record model="ir.ui.view" id="poweremail_inbox_tree">
 			<field name="name">poweremail.mailbox.inboxtree</field>
@@ -225,6 +243,15 @@
 			<field name="view_mode">form,tree</field>
 			<field name="view_id" ref="poweremail_conversation_tree" />
 		</record>
+		<!--ALL EMAILS-->
+		<record model="ir.actions.act_window" id="action_poweremail_all_emails_tree">
+			<field name="name">Mailbox: All emails</field>
+			<field name="res_model">poweremail.mailbox</field>
+			<field name="view_type">form</field>
+			<field name="view_mode">form,tree</field>
+			<field name="view_id" ref="poweremail_all_emails_tree" />
+			<field name="domain">[('pem_user','=',uid)]</field>
+		</record>
 		<!--INBOX-->
 		<record model="ir.actions.act_window" id="action_poweremail_inbox_tree">
 			<field name="name">Mailbox: Inbox</field>
@@ -280,6 +307,15 @@
 			<field name="domain">[('folder','=','trash'),('pem_user','=',uid)]</field>
 		</record>
 		<!--company-->
+		<!--ALL EMAILS-->
+		<record model="ir.actions.act_window" id="action_poweremail_all_emails_tree_company">
+			<field name="name">Mailbox: All emails</field>
+			<field name="res_model">poweremail.mailbox</field>
+			<field name="view_type">form</field>
+			<field name="view_mode">form,tree</field>
+			<field name="view_id" ref="poweremail_all_emails_tree" />
+			<field name="context">{'company':True}</field>
+		</record>
 		<!--INBOX-->
 		<record model="ir.actions.act_window" id="action_poweremail_inbox_tree_company">
 			<field name="name">Mailbox: Inbox</field>
@@ -353,6 +389,7 @@
 		<!--8888888888888888888888888888888888 MENUS 8888888888888888888888888888888888888888-->
 		<menuitem name="MailBox" id="menu_poweremail_mailbox_all_main2" parent="menu_poweremail_administration_server" />
 		<menuitem name="Personal" id="menu_poweremail_personal" parent="menu_poweremail_mailbox_all_main2" />
+		<menuitem name="All emails" id="menu_poweremail_all_emails" parent="menu_poweremail_personal" action="action_poweremail_all_emails_tree" />
 		<menuitem name="Inbox" id="menu_poweremail_inbox" parent="menu_poweremail_personal" action="action_poweremail_inbox_tree" />
 		<menuitem name="Inbox Conversations" id="menu_poweremail_inbox_conversation" parent="menu_poweremail_personal" action="action_poweremail_conversation_tree" />
 		<menuitem name="Drafts" id="menu_poweremail_drafts" parent="menu_poweremail_personal" action="action_poweremail_drafts_tree" />
@@ -362,6 +399,7 @@
 		<menuitem name="Trash" id="menu_poweremail_trash" parent="menu_poweremail_personal" action="action_poweremail_trash_tree" />
 
 		<menuitem name="Company" id="menu_poweremail_company" parent="menu_poweremail_mailbox_all_main2" />
+		<menuitem name="All emails" id="menu_poweremail_all_emails_company" parent="menu_poweremail_company" action="action_poweremail_all_emails_tree_company" />.
 		<menuitem name="Inbox" id="menu_poweremail_inbox_company" parent="menu_poweremail_company" action="action_poweremail_inbox_tree_company" />
 		<menuitem name="Drafts" id="menu_poweremail_drafts_company" parent="menu_poweremail_company" action="action_poweremail_drafts_tree_company" />
 		<menuitem name="Outbox" id="menu_poweremail_outbox_company" parent="menu_poweremail_company" action="action_poweremail_outbox_tree_company" />


### PR DESCRIPTION
## Objetivos:

- Meter tanto en el buzón personal como en el de la compañía un menú para mostrar todos los emails independientemente que sean enviados, recibidos, borradores, etc.

![image](https://github.com/gisce/poweremail/assets/101136796/31b1991c-8242-406e-a394-72f95d71be7e)
