### PR TITLE
Arreglar el asistente para generar correos de prueba

### DIFF
--- a/migrations/5.0.23.9.0/post-0001_fix_generate_test_email.py
+++ b/migrations/5.0.23.9.0/post-0001_fix_generate_test_email.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info('Fix generate test email...')
+
+    view = "wizard/wizard_generate_test_email.xml"
+    view_record = ["view_wizard_generate_email_form"]
+
+    logger.info("Updating XML {}".format(view))
+    load_data_records(cursor, 'poweremail', view, view_record, mode='update')
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/wizard/wizard_generate_test_email.xml
+++ b/wizard/wizard_generate_test_email.xml
@@ -1,4 +1,3 @@
-
 <openerp>
 	<data>
         <record id="action_wizard_generate_email_form" model="ir.actions.act_window">
@@ -21,7 +20,7 @@
         </record>
 
         <!--Finestra de dins de l'assistent-->
-        <record id="view_wizard_send_email_form" model="ir.ui.view">
+        <record id="view_wizard_generate_email_form" model="ir.ui.view">
 	    	<field name="name">wizard.generate.test.email.form</field>
 	      	<field name="model">wizard.generate.test.email</field>
 	      	<field name="type">form</field>


### PR DESCRIPTION
 - Arreglar el asistente para generar correos de prueba

- Antes
![image](https://github.com/gisce/poweremail/assets/137047111/6637279c-0e5c-47b8-b532-0dd6d7775eac)

- Despues
![image](https://github.com/gisce/poweremail/assets/137047111/83ad4fbf-4f1a-4e9c-9a77-e32a7b8a6467)

- [x] Actualización módulos:
    - poweremail

- [x] Migración de datos:
    - poweremail
