### PR TITLE
Mostrar la fecha de creación del correo en los principales listados

### DIFF
--- a/migrations/5.0.23.9.0/post-0008_add_create_date.py
+++ b/migrations/5.0.23.9.0/post-0008_add_create_date.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import logging
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    logger.info('Adding the menu to see all the emails')
+
+    view = "poweremail_mailbox_view.xml"
+    view_record = [
+        "poweremail_all_emails_tree",
+        "poweremail_inbox_tree",
+        "poweremail_drafts_tree",
+        "poweremail_outbox_tree",
+        "poweremail_sentbox_tree",
+        "poweremail_followbox_tree",
+        "poweremail_trashbox_tree",
+        "poweremail_errorbox_tree",
+    ]
+    logger.info("Updating XML {}".format(view))
+    load_data_records(
+        cursor, 'poweremail', view, view_record, mode='update'
+    )
+    logger.info('XML successfully updated.')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -113,6 +113,7 @@
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
 					<field name="state" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -131,6 +132,7 @@
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
 					<field name="state" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -148,6 +150,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -165,6 +168,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -182,6 +186,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -199,6 +204,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -216,6 +222,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>
@@ -233,6 +240,7 @@
 					<field name="pem_attachments_ids" select="2" />
 					<field name="date_mail" select="2" />
 					<field name="pem_recd" colspan="2" />
+					<field name="create_date" select="1"/>
 				</tree>
 			</field>
 		</record>


### PR DESCRIPTION
Se añade el campo data de creación en los filtros de las bandejas de correo.