### PR TITLE
ADD añadir un botón que permita eliminar la acción ligada a un template

### DIFF
--- a/migrations/5.0.23.12.0/post-0001_reload_poweremail_template_form.py
+++ b/migrations/5.0.23.12.0/post-0001_reload_poweremail_template_form.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+import logging
+import pooler
+from oopgrade.oopgrade import load_data, load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger('openerp.migration')
+
+    ##UPDATAR UNA PART DE L'XML (POSAR LA ID)##
+    logger.info("Updating XMLs")
+    list_of_records = [
+        "poweremail_template_form"
+    ]
+    load_data_records(
+        cursor, 'poweremail', 'poweremail_template_view.xml',
+        list_of_records, mode='update'
+    )
+    logger.info("XMLs succesfully updated.")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1131,6 +1131,18 @@ class poweremail_templates(osv.osv):
                 'ref_ir_value': ref_ir_value,
             }, context)
 
+    def delete_action_reference(self, cursor, uid, ids, context):
+        template = self.pool.get('poweremail.templates').browse(
+            cursor, uid, ids[0]
+        )
+        if template:
+            if template.ref_ir_act_window:
+                self.write(cursor, uid, template.id, {
+                    'ref_ir_act_window': None,
+                    'ref_ir_value': None,
+                })
+
+
 
 poweremail_templates()
 

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -149,7 +149,7 @@
                             />
                             <button
                                 string="Delete action and value"
-                                colspan="2" name="delete_action_reference"
+                                colspan="1" name="delete_action_reference"
                                 type="object"
                                 attrs="{'invisible':[('ref_ir_act_window', '==', False), ('ref_ir_value', '==', False)]}"
                                 icon="gtk-delete"

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -144,8 +144,15 @@
                                 string="Create action and value"
                                 colspan="1" name="create_action_reference"
                                 type="object"
-                                attrs="{'readonly':[('ref_ir_act_window', '!=', False), ('ref_ir_value', '!=', False)]}"
+                                attrs="{'invisible':[('ref_ir_act_window', '!=', False), ('ref_ir_value', '!=', False)]}"
                                 icon="gtk-execute"
+                            />
+                            <button
+                                string="Delete action and value"
+                                colspan="2" name="delete_action_reference"
+                                type="object"
+                                attrs="{'invisible':[('ref_ir_act_window', '==', False), ('ref_ir_value', '==', False)]}"
+                                icon="gtk-delete"
                             />
                             <separator string="Expression builder" colspan="4"/>
                             <field name="template_language" on_change="onchange_null_value(model_object_field,sub_model_object_field,null_value,template_language,context)" colspan="4"/>


### PR DESCRIPTION
## DESCRIPCIÓN (Obligatorio)
- Funcionalidad que permite eliminar una 'action_window' ligado a un email-template.

## CAPTURAS (Obligatorio)
![image](https://github.com/gisce/poweremail/assets/150009039/d26e19c7-96c9-48b0-9759-3f9dec645a68)
![image](https://github.com/gisce/poweremail/assets/150009039/a78bfb5f-cdc2-45db-b2cb-08a271dc8033)





