### PR TITLE
Add template body text optional inliner

### DIFF
--- a/migrations/5.0.24.5.0/post-0002_activar_inliner.py
+++ b/migrations/5.0.24.5.0/post-0002_activar_inliner.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+import logging
+import pooler
+
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+    logger.info("Creating pooler")
+    pool = pooler.get_pool(cursor.dbname)
+
+    # Afegir columna a poweremail.templates
+    logger.info("Updating table table: poweremail.templates")
+    pool.get("poweremail.templates")._auto_init(
+        cursor, context={"module": "poweremail"}
+    )
+    logger.info("Table updated succesfully.")
+
+    list_of_records = [
+        "poweremail_template_form",
+    ]
+    load_data_records(
+        cursor, "poweremail", "poweremail_template_view.xml",
+        list_of_records, mode="update"
+    )
+    logger.info("poweremail_template_view.xml successfully updated")
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/migrations/5.0.24.5.0/post-0002_activar_inliner.py
+++ b/migrations/5.0.24.5.0/post-0002_activar_inliner.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import logging
 import pooler
-from tools import pip_install
 
 from oopgrade.oopgrade import load_data_records
 
@@ -29,10 +28,6 @@ def up(cursor, installed_version):
         list_of_records, mode="update"
     )
     logger.info("poweremail_template_view.xml successfully updated")
-
-    logger.info('Installing premailer package...')
-    pip_install('premailer==2.9.6', '--force')
-    logger.info('Premailer package installed successfully!')
 
 
 def down(cursor, installed_version):

--- a/migrations/5.0.24.5.0/post-0002_activar_inliner.py
+++ b/migrations/5.0.24.5.0/post-0002_activar_inliner.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import logging
 import pooler
+from tools import pip_install
 
 from oopgrade.oopgrade import load_data_records
 
@@ -28,6 +29,10 @@ def up(cursor, installed_version):
         list_of_records, mode="update"
     )
     logger.info("poweremail_template_view.xml successfully updated")
+
+    logger.info('Installing premailer package...')
+    pip_install('premailer==2.9.6', '--force')
+    logger.info('Premailer package installed successfully!')
 
 
 def down(cursor, installed_version):

--- a/migrations/5.0.24.5.0/pre-0001_instalar_premailer.py
+++ b/migrations/5.0.24.5.0/pre-0001_instalar_premailer.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+import logging
+from tools import pip_install
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    logger = logging.getLogger("openerp.migration")
+    logger.info('Installing premailer package...')
+    pip_install('premailer==2.9.6', '--force')
+    logger.info('Premailer package installed successfully!')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -31,6 +31,7 @@ from tools.translate import _
 import tools
 from .poweremail_template import get_value
 from .poweremail_core import filter_send_emails, _priority_selection
+from premailer import transform
 
 
 class poweremail_send_wizard(osv.osv_memory):
@@ -138,7 +139,11 @@ class poweremail_send_wizard(osv.osv_memory):
         if len(context['src_rec_ids']) > 1: # Multiple Mail: Gets original template values for multiple email change
             return getattr(template, field)
         else: # Simple Mail: Gets computed template values
-            return self.get_value(cr, uid, template, getattr(template, field), context)
+            value = self.get_value(cr, uid, template, getattr(template, field), context)
+            if template.inline and field == 'def_body_text':
+                value = transform(value)
+
+            return value
 
     _columns = {
         'state':fields.selection([
@@ -495,6 +500,9 @@ class poweremail_send_wizard(osv.osv_memory):
                 # Options:'multipart/mixed','multipart/alternative','text/plain','text/html'
             }
             ctx = context.copy()
+            if template.inline:
+                vals['pem_body_text'] = transform(vals['pem_body_text'])
+
             mail_id = self.create_mail(cr, uid, screen_vals, src_rec_id, vals, context=ctx)
             mail_ids.append(mail_id)
             # Ensure report is rendered using template's language. If not found, user's launguage is used.

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -69,6 +69,7 @@ except:
 import tools
 import report
 import pooler
+from premailer import transform
 from .poweremail_mailbox import _priority_selection
 from .poweremail_core import get_email_default_lang
 

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -512,6 +512,7 @@ class poweremail_templates(osv.osv):
                                              relation='ir.attachment',
                                              string='Attachments'),
         'attach_record_items': fields.boolean('Attach record items', select=2, help=u"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."),
+        'inline': fields.boolean('Inline HTML', help=u"Si es marca aquesta opcio, l'html passara per un proces d'inline"),
         'model_data_name': fields.function(
             _get_model_data_name, string='Code',
             type='char', size=250, method=True,
@@ -523,7 +524,8 @@ class poweremail_templates(osv.osv):
     _defaults = {
         'ref_ir_act_window': False,
         'ref_ir_value': False,
-        'def_priority': lambda *a: '1'
+        'def_priority': lambda *a: '1',
+        'inline': lambda *a: False
     }
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))
@@ -1039,6 +1041,10 @@ class poweremail_templates(osv.osv):
             'priority': template.def_priority,
             'template_id': template.id,
         }
+
+        if template.inline:
+            mailbox_values['pem_body_text'] = transform(mailbox_values['pem_body_text'])
+
         #Use signatures if allowed
         if template.use_sign:
             sign = users_obj.read(cursor, user, user, ['signature'], context=context)['signature']

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -513,7 +513,7 @@ class poweremail_templates(osv.osv):
                                              relation='ir.attachment',
                                              string='Attachments'),
         'attach_record_items': fields.boolean('Attach record items', select=2, help=u"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."),
-        'inline': fields.boolean('Inline HTML', help=u"Si es marca aquesta opcio, l'html passara per un proces d'inline"),
+        'inline': fields.boolean('Inline HTML', help=u"If the option is checked, the CSS will be inlined inside the HTML"),
         'model_data_name': fields.function(
             _get_model_data_name, string='Code',
             type='char', size=250, method=True,

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -130,6 +130,7 @@
                                 <field name="single_email" colspan="4"/>
                                 <field name="use_sign" colspan="4"/>
                                 <field name="save_to_drafts" colspan="4"/>
+                                <field name="inline" colspan="4"/>
                             </group>
                             <group>
                                 <separator colspan="4" string="Allowed User Groups" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mako
 qreu>=0.7.5
 html2text
+premailer==2.9.6


### PR DESCRIPTION
## Objectius

Cada visualitzador de e-mails implementa la visualització HTML una mica diferent i això fa que la visualització de e-mails sigui a part de complicada, poc cohesionada.

Una de les solucions més comunes per intentar cohesionar la visualització al màxim és posar el CSS dintre de cada etiqueta (inlining) d'aquesta manera els visualitzadors no poden "decidir" tant i els més antics suporten millor el CSS.

L'inlining es pot activar o desactivar a través d'un boolean a la plantilla del correu.

## Comportament amb inlining

L'exemple més bàsic de la llibreria i amb el que passem als testos

Codi sense inlining.

```
<html>
<style type="text/css">
h1 { border:1px solid black }
p { color:red;}
</style>
<h1 style="font-weight:bolder">Peter</h1>
<p>Hej</p>
</html>
```

Un cop passat l'inlining

```
<html>
<h1 style="font-weight:bolder; border:1px solid black">Peter</h1>
<p style="color:red">Hej</p>
</html>
```

La PR conté testos per totes les funcions tocades i un script de migració.
