### PR TITLE
Eliminar atributo invisible del campo smtppass de las cuentas de poweremail

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -98,8 +98,7 @@ class poweremail_core_accounts(osv.osv):
         'smtpuname': fields.char('User Name',
                         size=120, required=False,
                         readonly=True, states={'draft':[('readonly', False)]}),
-        'smtppass': fields.char('Password',
-                        size=120, invisible=True,
+        'smtppass': fields.char('Password', size=120,
                         required=False, readonly=True,
                         states={'draft':[('readonly', False)]}),
         'smtptls': fields.boolean(


### PR DESCRIPTION
## Comportamieno nuevo
Se eliminar atributo invisible del campo smtppass de las cuentas de poweremail ya que provoca que en el webclient no se visualice correctamente el campo.

## Closes Issue https://github.com/gisce/poweremail/issues/157 on webclient repository