### PR TITLE
Poder treure accions d'una plantilla

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -634,6 +634,8 @@ class poweremail_templates(osv.osv):
         if check:
             new_name = new_name + '_' + random.choice('abcdefghij') + random.choice('lmnopqrs') + random.choice('tuvwzyz')
         default.update({'name':new_name})
+        # Clean no to copy values
+        default.update({'ref_ir_act_window':False, 'ref_ir_value': False})
         return super(poweremail_templates, self).copy(cr, uid, id, default, context)
 
     def compute_pl(self,

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1180,6 +1180,23 @@ class poweremail_templates(osv.osv):
                 'ref_ir_value': ref_ir_value,
             }, context)
 
+    def remove_action_reference(self, cursor, uid, ids, context):
+        values_obj = self.pool.get('ir.values')
+        action_obj = self.pool.get('ir.actions.act_window')
+        template = self.pool.get('poweremail.templates').browse(
+            cursor, uid, ids[0]
+        )
+
+        if template.ref_ir_act_window:
+            action_id = template.ref_ir_act_window.id
+            template.write({'ref_ir_act_window': False})
+            action_obj.unlink(cursor, uid, action_id)
+
+        if template.ref_ir_value:
+            value_id = template.ref_ir_value.id
+            template.write({'ref_ir_value': False})
+            values_obj.unlink(cursor, uid, value_id)
+
 
 poweremail_templates()
 

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -148,6 +148,13 @@
                                 attrs="{'readonly':[('ref_ir_act_window', '!=', False), ('ref_ir_value', '!=', False)]}"
                                 icon="gtk-execute"
                             />
+                            <button
+                                string="Remove action and value"
+                                colspan="1" name="remove_action_reference"
+                                type="object"
+                                attrs="{'readonly':[('ref_ir_act_window', '=', False), ('ref_ir_value', '=', False)]}"
+                                icon="gtk-execute"
+                            />
                             <separator string="Expression builder" colspan="4"/>
                             <field name="template_language" on_change="onchange_null_value(model_object_field,sub_model_object_field,null_value,template_language,context)" colspan="4"/>
                             <notebook colspan="4">

--- a/tests/test_poweremail_templates.py
+++ b/tests/test_poweremail_templates.py
@@ -97,3 +97,19 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
         })
         wiz = send_obj.browse(cursor, uid, wiz_id)
         self.assertEqual(wiz.priority, '2')
+
+    def test_remove_action_reference(self):
+        tmpl_obj = self.openerp.pool.get('poweremail.templates')
+        cursor = self.cursor
+        uid = self.uid
+        tmpl_id = self.create_template()
+        template = tmpl_obj.browse(cursor, uid, tmpl_id)
+        template.create_action_reference({})
+        template = tmpl_obj.browse(cursor, uid, tmpl_id)
+        self.assertTrue(template.ref_ir_act_window)
+        self.assertTrue(template.ref_ir_value)
+        template = tmpl_obj.browse(cursor, uid, tmpl_id)
+
+        template.remove_action_reference({})
+        self.assertFalse(template.ref_ir_act_window)
+        self.assertFalse(template.ref_ir_value)


### PR DESCRIPTION
# Objectius

Posar una mica d'endreça a les accions de finestra de les plantilles de poweremail. Actualment tenim vàries plantilles que apunten a la mateixa acció, tot i que sempre es crida la primera plantilla que va crear l'acció.
Quan ens trobem aquest cas, no podem eliminar l'acció de la plantilla i crear-ne una de nova.

# Funcionament antic

- Quan es duplicava una plantilla, es copiaven també els ids de les accions, i per tant a la plantilla nova hi havia l'acció que cridava a la plantilla vella.
- Des del client es podien crear accions però no es podien esborrar

# Funcionament nou

- Quan es duplica una plantilla no es copien els ids de les accions
- S'ha afegit un botó per eliminar l'acció

![image](https://github.com/gisce/poweremail/assets/26488435/fa234061-bb09-4dd9-821e-65c25f66cd94)
