### PR TITLE
Poder importar ficheros .mako en el cuerpo de la plantilla de Poweremail y nuevas variables en el scope de la plantilla

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,8 +29,7 @@ from . import poweremail_send_wizard
 from . import poweremail_mailbox
 from . import poweremail_serveraction
 from . import wizard
-
-from . import wizard
+from . import utils
 
 import logging
 

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -39,10 +39,12 @@ TEMPLATE_ENGINES = []
 from osv import osv, fields
 from tools.translate import _
 from tools.safe_eval import safe_eval
+from tools import config
 #Try and check the available templating engines
 from mako.template import Template  #For backward combatibility
 try:
     from mako.template import Template as MakoTemplate
+    from mako.lookup import TemplateLookup
     from mako import exceptions
     TEMPLATE_ENGINES.append(('mako', 'Mako Templates'))
 except:
@@ -193,13 +195,18 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
                 'db': cursor.dbname
             })
             if template.template_language == 'mako':
-                templ = MakoTemplate(message, input_encoding='utf-8')
+                addons_lookup = TemplateLookup(
+                    directories=[config['addons_path']], input_encoding='utf-8'
+                )
+                templ = MakoTemplate(message, input_encoding='utf-8', lookup=addons_lookup)
                 extra_render_values = env.get('extra_render_values', {}) or {}
                 values = {
                     'object': object,
                     'peobject': object,
                     'env': env,
                     'format_exceptions': True,
+                    'template': template,
+                    'lang': context.get('lang', config.get('default_lang', 'en_US')),
                 }
                 values.update(extra_render_values)
                 reply = templ.render_unicode(**values)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+import pooler
+
+
+class Localizer(object):
+    def __init__(self, cursor, uid, lang):
+        pool = pooler.get_pool(cursor.dbname)
+
+        lang_o = pool.get('res.lang')
+        lang_id = lang_o.search(cursor, uid, [('code', '=', lang)])[0]
+        self.lang = lang_o.simple_browse(cursor, uid, lang_id)
+
+    def amount(self, amount, digits=2, monetary=True):
+        return self.lang.format('%.{}f'.format(digits), amount, monetary=monetary)
+
+    def date(self, date_str):
+        new_format = self.lang.date_format
+        return datetime.strptime(date_str, "%Y-%m-%d").strftime(new_format)
+
+    def datetime(self, datetime_str):
+        new_format = "{} {}".format(self.lang.date_format, self.lang.time_format)
+        return datetime.strptime(datetime_str, "%Y-%m-%d").strftime(new_format)


### PR DESCRIPTION
## Objetivo

Facilitar el desarrollo de las plantillas de PowerEmail

## Comportamiento antiguo

- No se pueden realizar _imports_  en el cuerpo de la plantilla de Poweremail lo que obliga a que el código HTML del correo esté todo dentro del _body_ de la plantilla.
- Para obtener determinadas variables muy utilizadas (cursor, uid, etc) se debe repetir siempre el mismo código en cada plantilla (object._cursor, object._uid, etc)

## Comportamiento nuevo

- Ahora se puede modularizar el contenido de la plantilla de Poweremail. Por ejemplo:

```HTML
<!doctype html>
<%namespace file="/poweremail/emails/generic/components/header.mako" import="*"/>
<%namespace file="/poweremail/emails/generic/components/body.mako" import="*"/>
<%namespace file="/poweremail/emails/generic/components/footer.mako" import="*"/>
<%namespace file="/poweremail/emails/generic/components/css.mako" import="*"/>
...
```
- Ahora en el scope de la plantilla se pueden consultar directamente las siguientes variables:
    - `pool`
    - `cursor`
    - `uid`
    - `template`: _browse record_ de `poweremeail.template`
    - `lang` (`es_ES`, `ca_ES`, ...)
    - `localize`: objecte que permet _formatar_ valors en funció de l'idioma de la plantilla. p.e: 
    ```
    > localize.amount(3.5)
    "3,5"
    > localize.date("2024-02-01")
    "01/02/2024"
    ```