### PR TITLE
Mejorar la vista del asistente de "Previsualizar plantilla de correo"

### DIFF
--- a/wizard/wizard_poweremail_preview.xml
+++ b/wizard/wizard_poweremail_preview.xml
@@ -11,16 +11,23 @@
                     <field name="state" invisible="1"/>
                     <field name="model_ref" colspan="4"/>
                     <field name="to" colspan="4"/>
-                    <field name="cc" colspan="4"/>
-                    <field name="bcc" colspan="4"/>
+                    <field name="cc" colspan="2"/>
+                    <field name="bcc" colspan="2"/>
                     <field name="subject" colspan="4"/>
-                    <field name="body_text" colspan="4"/>
+                    <notebook>
+                        <page string="Body preview">
+                            <field name="body_text" colspan="4" widget="html_preview" nolabel="1"/>
+                        </page>
+                        <page string="Body HTML">
+                            <field name="body_text" colspan="4" nolabel="1"/>
+                        </page>
+                    </notebook>
                     <field name="report" colspan="4"/>
-                    <field name="save_to_drafts_prev" colspan="4"/>
-                    <button icon="gtk-close" special="cancel" string="Close" />
-                    <button name="action_generate_static_mail" icon="gtk-refresh" string="Preview Email" type="object"/>
+                    <separator colspan="2"/>
+                    <field name="save_to_drafts_prev" colspan="2"/>
+                    <button name="action_generate_static_mail" icon="gtk-refresh" string="Preview Email" type="object" colspan="2"/>
                     <button name="action_send_static_mail" icon="send" string="Send Email" type="object"
-                            attrs="{'invisible':[('state','=','error')]}"/>
+                            attrs="{'invisible':[('state','=','error')]}" colspan="2"/>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
## Comportamiento antiguo

![imagen](https://github.com/user-attachments/assets/383220fe-8c69-4c09-b76b-be30f4bc3988)

## Comportamiento nuevo

- Se ha añadido la posibilidad de ver el contenido del correo renderizado
- Se ha eliminado el botón de cerrar
- Se ha movido a una sola fila la copia y la copia oculta

![imagen](https://github.com/user-attachments/assets/c2ac6cac-1b02-4d0f-b1cc-5c2c1efa6a3f)
