### PR TITLE
No se renderizaba el contenido del email si no se encontraba idioma

### DIFF
--- a/migrations/5.0.24.9.0/post-0003_update_preview_email_view.py
+++ b/migrations/5.0.24.9.0/post-0003_update_preview_email_view.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import load_data_records
+
+
+def up(cursor, installed_version):
+    if not installed_version:
+        return
+
+    load_data_records(cursor, 'poweremail', 'wizard/wizard_poweremail_preview.xml', ['poweremail_preview_form'])
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -220,6 +220,8 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
                 env['object'] = object
                 env['peobject'] = object
                 reply = templ.render(Context(env))
+                if reply == 'False':
+                    reply = False
             return reply or False
         except Exception as e:
             if context.get('raise_exception', False):

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -215,6 +215,8 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
                 }
                 values.update(extra_render_values)
                 reply = templ.render_unicode(**values)
+                if reply == 'False':
+                    reply = False
             elif template.template_language == 'django':
                 templ = DjangoTemplate(message)
                 env['object'] = object

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -51,6 +51,7 @@ class poweremail_preview(osv.osv_memory):
         'cc': fields.char('CC', size=250, readonly=True),
         'bcc': fields.char('BCC', size=250, readonly=True),
         'subject': fields.char('Subject', size=200, readonly=True),
+        'lang': fields.char('Language', size=6, readonnly=True),
         'body_text': fields.text('Body', readonly=True),
         'body_html': fields.text('Body', readonly=True),
         'report': fields.char('Report Name', size=100, readonly=True),
@@ -75,7 +76,6 @@ class poweremail_preview(osv.osv_memory):
         if not wizard_values:
             return {}
 
-        vals = {}
         wizard_values = wizard_values[0]
         model_name, record_id = wizard_values['model_ref'].split(',')
         record_id = int(record_id)
@@ -88,6 +88,7 @@ class poweremail_preview(osv.osv_memory):
             ctx.update({'lang': lang})
             template = self.pool.get('poweremail.templates').browse(cr, uid, context['active_id'], ctx)
 
+        vals = {'lang': lang}
         mail_fields = ['to', 'cc', 'bcc', 'subject', 'body_text', 'body_html', 'report']
         ctx['raise_exception'] = True
         if wizard_values['env']:

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -88,7 +88,7 @@ class poweremail_preview(osv.osv_memory):
             ctx.update({'lang': lang})
             template = self.pool.get('poweremail.templates').browse(cr, uid, context['active_id'], ctx)
 
-        vals = {'lang': lang}
+        vals = {'lang': str(lang)}
         mail_fields = ['to', 'cc', 'bcc', 'subject', 'body_text', 'body_html', 'report']
         ctx['raise_exception'] = True
         if wizard_values['env']:

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -51,7 +51,7 @@ class poweremail_preview(osv.osv_memory):
         'cc': fields.char('CC', size=250, readonly=True),
         'bcc': fields.char('BCC', size=250, readonly=True),
         'subject': fields.char('Subject', size=200, readonly=True),
-        'lang': fields.char('Language', size=6, readonnly=True),
+        'lang': fields.char('Language', size=6, readonly=True),
         'body_text': fields.text('Body', readonly=True),
         'body_html': fields.text('Body', readonly=True),
         'report': fields.char('Report Name', size=100, readonly=True),

--- a/wizard/wizard_poweremail_preview.xml
+++ b/wizard/wizard_poweremail_preview.xml
@@ -10,9 +10,10 @@
                 <form string="Power Email Preview">
                     <field name="state" invisible="1"/>
                     <field name="model_ref" colspan="4"/>
-                    <field name="to" colspan="4"/>
+                    <field name="to" colspan="2"/>
                     <field name="cc" colspan="2"/>
                     <field name="bcc" colspan="2"/>
+                    <field name="lang" colspan="2"/>
                     <field name="subject" colspan="4"/>
                     <field name="env" colspan="4" widget="codeeditor" widget_props="{'lang': 'json'}" height="100"/>
                     <notebook>


### PR DESCRIPTION
## Comportamiento antiguo

Si al evaluar el registro no se encontraba idioma (False), no se podía renderizar el cuerpo del correo (tampoco los destinatarios)

## Comportamiento nuevo

Aunque no se encuentre el idioma según el registro, se renderiza el correo en función del idioma por defecto del ERP

También se ha añadido un campo en el asistente que visualiza el idioma, para detectar que idioma se está obteniendo:

![imagen](https://github.com/user-attachments/assets/cde10fd5-8a8e-4219-9ffb-7446e04bbe26)

## Origen del error

https://github.com/gisce/poweremail/pull/163/

## Descripción del error

La nueva clase `Localize` necesita obligatoriamente un idioma para poder funcionar. Cuando se evalúa el idioma y el registro en cuestión no tiene (False), el resultado del idioma de la plantilla es "False" (string). Este "idioma" se pasa al resto de variables a evaluar (body, cc, bcc, etc) el cual no es un idioma existente por lo que la clase `Localize` falla al instanciarse.