### PR TITLE
Make attachments of other models in poweremail.template

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -926,6 +926,7 @@ class poweremail_templates(osv.osv):
         attachment_obj = self.pool.get('ir.attachment')
         mailbox_obj = self.pool.get('poweremail.mailbox')
         lang = get_value(cursor, user, record_ids[0], template.lang, template, context=context)
+        record_reference_ids = record_ids
         ctx = context.copy()
         if lang:
             ctx['lang'] = lang
@@ -934,7 +935,12 @@ class poweremail_templates(osv.osv):
             ctx['lang'] = tools.config.get('lang', 'en_US')
         attachment_id = []
         if template.report_template:
-            report_vals = self.create_report(cursor, user, template, record_ids, context=context)
+            if template.report_template_object_reference:
+                for record_id in record_ids:
+                    reference_ids = get_value(cursor, user, recid=record_id, message=template.report_template_object_reference, template=template, context=context)
+                    record_reference_ids += reference_ids
+
+            report_vals = self.create_report(cursor, user, template, record_reference_ids, context=context)
             result = report_vals[0]
             format = report_vals[1]
 


### PR DESCRIPTION
## Objetivos
- When you send a report attachment with poweremail now you can attach reports of other models differents from the template's reference model.

## Comportamiento antiguo
- N/A

## Comportamiento nuevo
Allow to attach to the mails, another data models with a regex like: `${get('<data_model>').search(cursor, uid, [(condition1), (condition2)])}`

## Afectaciones / Migración de datos

- [x] Código. Reiniciar servicios
- [ ] Actualización módulos:
    - especificar que módulos
- [ ] Migración de datos
- [ ] RFC a la descricpción del report (sólamente si es nuevo)
    - [Plantilla para documentar] (https://rfc.gisce.net/t/template-descripcio-dun-report-generic-a-lrfc/1439/1)

## Relacionado
- Needs: https://github.com/gisce/poweremail/pull/85
