### PR TITLE
Registrar error cuando falla el proceso de renderizar email

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -31,6 +31,7 @@ import time
 import types
 import netsvc
 import six
+import sentry_sdk
 
 LOGGER = netsvc.Logger()
 
@@ -225,6 +226,8 @@ def get_value(cursor, user, recid, message=None, template=None, context=None):
                     reply = False
             return reply or False
         except Exception as e:
+            msg = (_('An error occurred while rendering template id {}:  {}'.format(template.id, e.message)))
+            sentry_sdk.capture_message(msg, 'warning')
             if context.get('raise_exception', False):
                 raise
             else:


### PR DESCRIPTION
## Objetivos

Poder llevar un seguimiento de los emails que no se pueden renderizar para detectar plantillas incorrectas