### PR TITLE
Add mako as default value of the template language

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -547,7 +547,7 @@ class poweremail_templates(osv.osv):
         'ref_ir_value': False,
         'def_priority': lambda *a: '1',
         'inline': lambda *a: False,
-        'template_language': lambda *a: ('mako', 'Plantilles Mako'),
+        'template_language': lambda *a: 'mako',
     }
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -546,7 +546,8 @@ class poweremail_templates(osv.osv):
         'ref_ir_act_window': False,
         'ref_ir_value': False,
         'def_priority': lambda *a: '1',
-        'inline': lambda *a: False
+        'inline': lambda *a: False,
+        'template_language': lambda *a: ('mako', 'Plantilles Mako'),
     }
     _sql_constraints = [
         ('name', 'unique (name)', _('The template name must be unique!'))


### PR DESCRIPTION
## New performance
With the function of creating a new template, a default value is added in the _Expression builder_, specifically in the _Templating Language_, Mako Templates will be assigned to it.
## Past performance
![mako_default_value_of_template](https://github.com/user-attachments/assets/c337e3f8-95ed-4d3b-a746-64fe810cbe3a)
## New performance
![mako_default_value_of_template2](https://github.com/user-attachments/assets/7d21e1b5-a1e5-48a5-af40-587e6c7e9240)
