### PR TITLE
Mailing list generated with a specific template mail

### DIFF
--- a/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
+++ b/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
@@ -9,7 +9,8 @@ def up(cursor, installed_version):
         return
 
     list_of_records = [
-        'action_template_emails', 'value_list_same_templates',
+        'action_template_emails',
+        'value_template_emails',
     ]
     load_data_records(
         cursor, 'poweremail', 'poweremail_mailbox_view.xml',

--- a/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
+++ b/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
@@ -14,7 +14,7 @@ def up(cursor, installed_version):
     ]
     load_data_records(
         cursor, 'poweremail', 'poweremail_mailbox_view.xml',
-        list_of_records, mode='update')
+        list_of_records, mode='init')
 
 
 def down(cursor, installed_version):

--- a/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
+++ b/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
@@ -9,7 +9,7 @@ def up(cursor, installed_version):
         return
 
     list_of_records = [
-        'link_all_same_templates', 'value_list_same_templates',
+        'action_template_emails', 'value_list_same_templates',
     ]
     load_data_records(
         cursor, 'poweremail', 'poweremail_mailbox_view.xml',

--- a/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
+++ b/migrations/5.0.25.1.0/post-0002_add_link_to_list_generated_emails.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from oopgrade.oopgrade import load_data_records
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    list_of_records = [
+        'link_all_same_templates', 'value_list_same_templates',
+    ]
+    load_data_records(
+        cursor, 'poweremail', 'poweremail_mailbox_view.xml',
+        list_of_records, mode='update')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -455,25 +455,25 @@
 		<menuitem name="Sending" id="menu_action_poweremail_sending_tree_company" parent="poweremail.menu_poweremail_company" action="action_poweremail_sending_tree_company" />
 		<menuitem name="Trash" id="menu_poweremail_trash_company" parent="menu_poweremail_company" action="action_poweremail_trash_tree_company" />
 		<menuitem name="Error" id="menu_poweremail_error_company" parent="menu_poweremail_company" action="action_poweremail_error_tree_company" />
-	<!-- LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
-		<record model="ir.actions.act_window" id="link_all_same_templates">
-            <field name="name">List the mails generated with the same template</field>
-            <field name="src_model">poweremail.templates</field>
-            <field name="res_model">poweremail.mailbox</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">tree,form</field>
-            <field name="domain">[('template_id', '=',active_id)]</field>
-            <field name="view_id" ref="poweremail_all_emails_tree"/>
-        </record>
-        <record id="value_list_same_templates" model="ir.values">
-            <field name="object" eval="1"/>
-            <field name="name">List the mails generated with the same template</field>
-            <field name="key2">client_action_relate</field>
-            <field name="key">action</field>
-            <field name="model">poweremail.templates</field>
-            <field name="value" eval="'ir.actions.act_window,'+str(ref('link_all_same_templates'))" />
-        </record>
-	<!-- END LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
+		<!-- LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
+		<record model="ir.actions.act_window" id="action_template_emails">
+			<field name="name">Template emails</field>
+			<field name="src_model">poweremail.templates</field>
+			<field name="res_model">poweremail.mailbox</field>
+			<field name="view_type">form</field>
+			<field name="view_mode">tree,form</field>
+			<field name="domain">[('template_id', '=',active_id)]</field>
+			<field name="view_id" ref="poweremail_all_emails_tree"/>
+		</record>
+		<record id="value_list_same_templates" model="ir.values">
+			<field name="object" eval="1"/>
+			<field name="name">Template emails</field>
+			<field name="key2">client_action_relate</field>
+			<field name="key">action</field>
+			<field name="model">poweremail.templates</field>
+			<field name="value" eval="'ir.actions.act_window,'+str(ref('action_template_emails'))" />
+		</record>
+		<!-- END LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
 	</data>
 </openerp>
 

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -455,7 +455,25 @@
 		<menuitem name="Sending" id="menu_action_poweremail_sending_tree_company" parent="poweremail.menu_poweremail_company" action="action_poweremail_sending_tree_company" />
 		<menuitem name="Trash" id="menu_poweremail_trash_company" parent="menu_poweremail_company" action="action_poweremail_trash_tree_company" />
 		<menuitem name="Error" id="menu_poweremail_error_company" parent="menu_poweremail_company" action="action_poweremail_error_tree_company" />
-
+	<!-- LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
+		<record model="ir.actions.act_window" id="link_all_same_templates">
+            <field name="name">List the mails generated with the same template</field>
+            <field name="src_model">poweremail.templates</field>
+            <field name="res_model">poweremail.mailbox</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('template_id', '=',active_id)]</field>
+            <field name="view_id" ref="poweremail_all_emails_tree"/>
+        </record>
+        <record id="value_list_same_templates" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">List the mails generated with the same template</field>
+            <field name="key2">client_action_relate</field>
+            <field name="key">action</field>
+            <field name="model">poweremail.templates</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('link_all_same_templates'))" />
+        </record>
+	<!-- END LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
 	</data>
 </openerp>
 

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -465,7 +465,7 @@
 			<field name="domain">[('template_id', '=',active_id)]</field>
 			<field name="view_id" ref="poweremail_all_emails_tree"/>
 		</record>
-		<record id="value_list_same_templates" model="ir.values">
+		<record id="value_template_emails" model="ir.values">
 			<field name="object" eval="1"/>
 			<field name="name">Template emails</field>
 			<field name="key2">client_action_relate</field>


### PR DESCRIPTION
## Objective performance
When selecting a specific Power Email template, a function has been created in the “related” to show the list of emails that have been created from the selected template.

1.

![1](https://github.com/user-attachments/assets/95ad8b40-3ab9-4e05-a85a-b2acbe2e21e0)


2.

![2](https://github.com/user-attachments/assets/63de0db5-a91c-4ca8-9903-8cdc23938eeb)


## Past performance
![list_generated_emailsX](https://github.com/user-attachments/assets/670c935c-5b74-4ce0-9235-be4d455e41fc)

## Related

- TASK-69862