### PR TITLE
Force by context to not attach documents on when generating an email

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1120,11 +1120,12 @@ class poweremail_templates(osv.osv):
             mailbox_id = self._generate_mailbox_item_from_template(cursor, user, template, record_id, context=context)
             mailbox_ids.append(mailbox_id)
             mail = self.pool.get('poweremail.mailbox').browse(cursor, user, mailbox_id, context=context)
-            if template.single_email and len(report_record_ids) > 1:
-                # The optional attachment will be generated as a single file for all these records
-                self._generate_attach_reports(cursor, user, template, report_record_ids, mail, context=context)
-            else:
-                self._generate_attach_reports(cursor, user, template, [record_id], mail, context=context)
+            if context.get('add_attachments', True):
+                if template.single_email and len(report_record_ids) > 1:
+                    # The optional attachment will be generated as a single file for all these records
+                    self._generate_attach_reports(cursor, user, template, report_record_ids, mail, context=context)
+                else:
+                    self._generate_attach_reports(cursor, user, template, [record_id], mail, context=context)
             # Create a partner event
             cursor.execute("SELECT state from ir_module_module where state='installed' and name = 'mail_gateway'")
             mail_gateway = cursor.fetchall()


### PR DESCRIPTION
## Old behaviour

The generated email always have attachments wether the static and/or dynamic attachments are configured on the template.

## New behaviour

It can be forced to not attach any attachment on the generated email using the `add_attachments` flag passed on the context even when the template has static and/or dynamic attachments configured.