### PR TITLE
Relate generated email to resource when created from preview wizard

### DIFF
--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -140,7 +140,10 @@ class poweremail_preview(osv.osv_memory):
             if not template:
                 raise Exception("The requested template could not be loaded")
 
-            mailbox_id = template_obj.generate_mail(cursor, uid, template_id, model_id, context=context)
+            ctx = context.copy()
+            ctx['src_rec_id'] = model_id
+            ctx['src_model'] = template.object_name.model
+            mailbox_id = template_obj.generate_mail(cursor, uid, template_id, model_id, context=ctx)
 
             if wizard.save_to_drafts_prev:
                 mailbox_obj.write(cursor, uid, mailbox_id, {'folder': 'drafts'}, context=context)


### PR DESCRIPTION
## Old behaviour

The emails generated from the preview wizard were not related to the resource

## New behaviour

The emails generated from the preview wizard are related to the resource when the `poweremail_references` module is installed (the reference field on the mailbox model is filled).