### PR TITLE
Account field added to preview wizard

### DIFF
--- a/migrations/5.0.25.5.0/post-0002_add_account_to_preview_wizard.py
+++ b/migrations/5.0.25.5.0/post-0002_add_account_to_preview_wizard.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import load_data_records
+from tools import config
+import pooler
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    module_name = 'poweremail'
+
+    pool = pooler.get_pool(cursor.dbname)
+    pool.get("poweremail.preview")._auto_init(cursor, context={'module': module_name})
+
+    list_of_records = [
+        'poweremail_preview_form'
+    ]
+    load_data_records(
+        cursor, module_name, 'wizard/wizard_poweremail_preview.xml',
+        list_of_records, mode='update')
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/wizard/wizard_poweremail_preview.xml
+++ b/wizard/wizard_poweremail_preview.xml
@@ -10,6 +10,7 @@
                 <form string="Power Email Preview">
                     <field name="state" invisible="1"/>
                     <field name="model_ref" colspan="4"/>
+                    <field name="enforce_from_account" colspan="4" readonly="1"/>
                     <field name="to" colspan="2"/>
                     <field name="cc" colspan="2"/>
                     <field name="bcc" colspan="2"/>


### PR DESCRIPTION
## Objective
We want to add the account field in the email preview wizard and have it automatically filled in according to the template.

## Old behaviour
![imagen](https://github.com/user-attachments/assets/8152190d-e97d-46a8-a493-d97475aa9652)

![imagen](https://github.com/user-attachments/assets/e456cf79-afff-446e-8f12-66ba6f4b1ea4)

## New behaviour
![pemail_template1](https://github.com/user-attachments/assets/413900c5-0a21-499e-8742-39cffe8e6052)
![pemail_preview](https://github.com/user-attachments/assets/800f3765-063a-4b8f-b405-d737a25f7914)

## Requires
- Migration script:`v5.0.25.5.0`  `post-0002_add_account_to_preview_wizard.py`
- Module: poweremail
- Task: 71967
