### PR TITLE
Emails aren't being sent when the model has company as integer

### DIFF
--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1112,7 +1112,10 @@ class poweremail_templates(osv.osv):
                 if company_field:
                     record_company = record_model.read(cursor, user, record_id, [company_field], context=context)[company_field]
                     if record_company:
-                        ctx_company['company_id'] = record_company[0]
+                        if isinstance(record_company, list):
+                            ctx_company['company_id'] = record_company[0]
+                        else:
+                            ctx_company['company_id'] = record_company
         from_account = self.get_from_account_id_from_template(cursor, user, template.id, context=ctx_company)
 
         ctx = context.copy()

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1115,8 +1115,10 @@ class poweremail_templates(osv.osv):
 
                     if record_company_type == 'many2one':
                         ctx_company['company_id'] = record_company[0]
-                    else:
+                    elif record_company_type == 'integer':
                         ctx_company['company_id'] = record_company
+                    else:
+                        ctx_company['company_id'] = False
 
         from_account = self.get_from_account_id_from_template(cursor, user, template.id, context=ctx_company)
 

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1110,12 +1110,14 @@ class poweremail_templates(osv.osv):
                 else:
                     company_field = False
                 if company_field:
+                    record_company_type = record_model.fields_get(cursor, user)[company_field]['type']
                     record_company = record_model.read(cursor, user, record_id, [company_field], context=context)[company_field]
-                    if record_company:
-                        if isinstance(record_company, list):
-                            ctx_company['company_id'] = record_company[0]
-                        else:
-                            ctx_company['company_id'] = record_company
+
+                    if record_company_type == 'many2one':
+                        ctx_company['company_id'] = record_company[0]
+                    else:
+                        ctx_company['company_id'] = record_company
+
         from_account = self.get_from_account_id_from_template(cursor, user, template.id, context=ctx_company)
 
         ctx = context.copy()


### PR DESCRIPTION
## Objectives:
Emails from Oficina Virtual were not being sent in cases where the email model’s field was defined as an integer instead of a many2one relation.

This PR updates the logic to support both return types from record_model.read:

many2one → list [id, name]

integer → direct int

By handling both cases, ctx_company['company_id'] is set correctly and emails are sent as expected.