### PR TITLE
Modificar el formato del correo en las direcciones substituyen el separador ; por ,

### DIFF
--- a/migrations/5.0.25.5.0/post-0003_fix_format_with_more_than_one_email.py
+++ b/migrations/5.0.25.5.0/post-0003_fix_format_with_more_than_one_email.py
@@ -6,7 +6,7 @@ def up(cursor, installed_version):
     if not installed_version or config.updating_all:
         return
 
-    cursor.execute("UPDATE res_partner_address SET email = REPLACE(email, ';', ',') WHERE email LIKE '%;%';")
+    cursor.execute("UPDATE res_partner_address SET email = REPLACE(email, ';', ',') WHERE email LIKE '%;%'")
 
 def down(cursor, installed_version):
     pass

--- a/migrations/5.0.25.5.0/post-0003_fix_format_with_more_than_one_email.py
+++ b/migrations/5.0.25.5.0/post-0003_fix_format_with_more_than_one_email.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from tools import config
+
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    cursor.execute("UPDATE res_partner_address SET email = REPLACE(email, ';', ',') WHERE email LIKE '%;%';")
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up


### PR DESCRIPTION
# Context

Los correos en el campo `email` del `res_partner_address` se guardaban con `;`

# Relacionat 

- https://github.com/gisce/webclient/issues/2469