### PR TITLE
Mostrar botón Enviar despues de corregir un error

### DIFF
--- a/migrations/5.0.26.1.0/post-0001_btn_send_email.py
+++ b/migrations/5.0.26.1.0/post-0001_btn_send_email.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from oopgrade.oopgrade import MigrationHelper
+from tools import config
+
+def up(cursor, installed_version):
+    if config.updating_all or not installed_version:
+        return
+
+    module = 'poweremail'
+    helper = MigrationHelper(cursor, module)
+    record_ids = [
+        'poweremail_preview_form',
+    ]
+    helper.update_xml_records('wizard/wizard_poweremail_preview.xml',
+                              update_record_ids=record_ids)
+
+
+def down(cursor, installed_version):
+    pass
+
+
+migrate = up

--- a/tests/test_poweremail_templates.py
+++ b/tests/test_poweremail_templates.py
@@ -72,6 +72,66 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
             'date_mail': date_mail,
         })
 
+    def test_preview_recovers_after_fixing_scope(self):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        preview_obj = self.openerp.pool.get('poweremail.preview')
+        cursor = self.cursor
+        uid = self.uid
+
+        partner_id = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'res_partner_asus'
+        )[1]
+        template_id = self.create_template({
+            'def_to': 'recipient@example.com',
+            'def_body_text': '<a href="${button_url}">Sign</a>',
+        })
+        context = {
+            'active_id': template_id,
+            'active_ids': [template_id],
+        }
+        preview_id = preview_obj.create(cursor, uid, {
+            'model_ref': 'res.partner,{}'.format(partner_id),
+        }, context=context)
+
+        preview_obj.action_generate_static_mail(
+            cursor, uid, [preview_id], context=context
+        )
+        preview = preview_obj.browse(cursor, uid, preview_id)
+        self.assertEqual(preview.state, 'error')
+
+        preview_obj.write(cursor, uid, [preview_id], {
+            'env': (
+                "{'extra_render_values': "
+                "{'button_url': 'https://sign.example.com'}}"
+            ),
+        }, context=context)
+        preview_obj.action_generate_static_mail(
+            cursor, uid, [preview_id], context=context
+        )
+        preview = preview_obj.browse(cursor, uid, preview_id)
+        self.assertEqual(preview.state, 'init')
+        self.assertIn('https://sign.example.com', preview.body_text)
+
+    def test_preview_accepts_supported_recipient_separators(self):
+        imd_obj = self.openerp.pool.get('ir.model.data')
+        preview_obj = self.openerp.pool.get('poweremail.preview')
+        cursor = self.cursor
+        uid = self.uid
+
+        partner_id = imd_obj.get_object_reference(
+            cursor, uid, 'base', 'res_partner_asus'
+        )[1]
+        template_id = self.create_template()
+        preview_id = preview_obj.create(cursor, uid, {
+            'model_ref': 'res.partner,{}'.format(partner_id),
+            'to': 'first@example.com, second@example.com; third@example.com',
+        }, context={
+            'active_id': template_id,
+            'active_ids': [template_id],
+        })
+
+        self.assertTrue(preview_id)
+
     def test_creating_email_gets_default_priority(self):
 
         tmpl_obj = self.openerp.pool.get('poweremail.templates')

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -113,6 +113,9 @@ class poweremail_preview(osv.osv_memory):
         ctx['raise_exception'] = True
         if wizard_values['env']:
             ctx.update(eval(wizard_values['env']))
+
+        had_error = False
+
         for field in mail_fields:
             try:
                 if field == 'report':
@@ -128,11 +131,17 @@ class poweremail_preview(osv.osv_memory):
 
             except Exception as e:
                 if field == 'body_text':
+                    had_error = True
                     vals[field] = html_error_template().render()
                 else:
                     tb = traceback.format_tb(sys.exc_info()[2])
                     vals[field] = '{}\n{}'.format(e.message, ''.join(tb))
                 vals['state'] = 'error'
+
+        if had_error:
+            vals['state'] = 'error'
+        else:
+            vals['state'] = 'init'
 
         self.write(cr, uid, ids, vals, context=context)
         return True

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -114,7 +114,7 @@ class poweremail_preview(osv.osv_memory):
         if wizard_values['env']:
             ctx.update(eval(wizard_values['env']))
 
-        had_error = False
+        vals['state'] = 'init'
 
         for field in mail_fields:
             try:
@@ -131,17 +131,11 @@ class poweremail_preview(osv.osv_memory):
 
             except Exception as e:
                 if field == 'body_text':
-                    had_error = True
                     vals[field] = html_error_template().render()
                 else:
                     tb = traceback.format_tb(sys.exc_info()[2])
                     vals[field] = '{}\n{}'.format(e.message, ''.join(tb))
                 vals['state'] = 'error'
-
-        if had_error:
-            vals['state'] = 'error'
-        else:
-            vals['state'] = 'init'
 
         self.write(cr, uid, ids, vals, context=context)
         return True

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import sys
@@ -10,6 +11,7 @@ from tools.translate import _
 import tools
 from premailer import transform
 from osv.orm import Constraint, OnlyFieldsConstraint
+from tools.safe_eval import safe_eval
 
 
 class poweremail_preview(osv.osv_memory):
@@ -59,6 +61,19 @@ class poweremail_preview(osv.osv_memory):
         return res
 
     def onchange_model_ref(self, cr, uid, ids, model_ref, context=None):
+        """
+        A partir d'una referència del tipus 'model,id', calcula:
+          - l'idioma efectiu del correu segons la plantilla
+          - els camps de capçalera (to, cc, bcc, subject)
+        tenint en compte:
+          - el context actiu (active_id)
+          - l'entorn del wizard (env)
+          - expressions dinàmiques definides a la plantilla
+
+        :param model_ref: string 'model_name,record_id'
+        :return: dict {'value': {...}} per actualitzar el wizard
+        """
+
         context = context or {}
         res = {'value': {}}
 
@@ -69,23 +84,21 @@ class poweremail_preview(osv.osv_memory):
         record_id = int(record_id)
 
         template_obj = self.pool.get('poweremail.templates')
-        template = template_obj.browse(cr, uid, context['active_id'],
-                                       context=context)
+        template = template_obj.simple_browse(cr, uid, context['active_id'], context=context)
 
         lang = False
-        try:
-            if template.lang:
-                lang = get_value(cr, uid, record_id, template.lang, template,
-                                 context)
-        except Exception:
-            lang = context.get('lang') or False
+        if template.lang:
+            try:
+                lang = get_value(cr, uid, record_id, template.lang, template, context)
+            except Exception:
+                lang = context.get('lang') or False
 
         ctx = context.copy()
 
         if lang:
             ctx.update({'lang': lang})
-            template = template_obj.browse(cr, uid, context['active_id'], ctx)
-            res['value']['lang'] = str(lang)
+            template = template_obj.simple_browse(cr, uid, context['active_id'], ctx)
+            res['value']['lang'] = lang
 
         ctx['raise_exception'] = True
 
@@ -97,7 +110,7 @@ class poweremail_preview(osv.osv_memory):
 
         if wizard_env:
             try:
-                ctx.update(eval(wizard_env))
+                ctx.update(safe_eval(wizard_env))
             except Exception:
                 pass
 
@@ -115,6 +128,17 @@ class poweremail_preview(osv.osv_memory):
         return res
 
     def call_check_to(self, cr, uid, ids):
+        """
+        Aquesta funció comprova que totes les adreces de correu electrònic
+        definides al camp 'to' siguin vàlides. El camp s'espera en format
+        text amb múltiples adreces separades per comes.
+        Per cada adreça:
+          - Es valida el format mitjançant tools.misc.get_validate_email_format
+          - Si alguna adreça no és vàlida, la funció retorna False
+
+        :return: True si totes les adreces són vàlides, False en cas contrari
+        """
+
         to = self.read(cr, uid, ids, ['to'])[0]['to']
         res = True
         separator = ','

--- a/wizard/wizard_poweremail_preview.py
+++ b/wizard/wizard_poweremail_preview.py
@@ -8,9 +8,8 @@ from mako.exceptions import html_error_template
 from osv import osv, fields
 from ..poweremail_template import get_value
 from tools.translate import _
-import tools
 from premailer import transform
-from osv.orm import Constraint, OnlyFieldsConstraint
+from osv.orm import OnlyFieldsConstraint
 from tools.safe_eval import safe_eval
 
 
@@ -129,24 +128,15 @@ class poweremail_preview(osv.osv_memory):
 
     def call_check_to(self, cr, uid, ids):
         """
-        Aquesta funció comprova que totes les adreces de correu electrònic
-        definides al camp 'to' siguin vàlides. El camp s'espera en format
-        text amb múltiples adreces separades per comes.
-        Per cada adreça:
-          - Es valida el format mitjançant tools.misc.get_validate_email_format
-          - Si alguna adreça no és vàlida, la funció retorna False
+        Comprova el camp 'to' amb les mateixes regles i separadors que
+        s'utilitzen en enviar el correu.
 
         :return: True si totes les adreces són vàlides, False en cas contrari
         """
 
+        mailbox_obj = self.pool.get('poweremail.mailbox')
         to = self.read(cr, uid, ids, ['to'])[0]['to']
-        res = True
-        separator = ','
-        for email in to.split(separator):
-            is_valid = tools.misc.get_validate_email_format(email)
-            if not is_valid:
-                res = False
-        return res
+        return bool(to) and mailbox_obj.check_email_valid(to)
 
     _constraints = [
         OnlyFieldsConstraint(call_check_to,

--- a/wizard/wizard_poweremail_preview.xml
+++ b/wizard/wizard_poweremail_preview.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <form string="Power Email Preview">
                     <field name="state" invisible="1"/>
-                    <field name="model_ref" colspan="4"/>
+                    <field name="model_ref" colspan="4" on_change="onchange_model_ref(model_ref, context)"/>
                     <field name="enforce_from_account" colspan="4" readonly="1"/>
                     <field name="to" colspan="2"/>
                     <field name="cc" colspan="2"/>


### PR DESCRIPTION
## Objetivos

- Permitir que tras corregir las variables y volver a renderizar la plantilla, el botón de Enviar vuelva a mostrarse sin necesidad de reiniciar el asistente.

## Comportamiento antiguo

- Aunque se corrigieran las variables y se volviera a renderizar correctamente, el botón de Enviar no reaparecía, obligando a cerrar y volver a abrir el asistente.

- Error HTML

<img width="1296" height="903" alt="imagen" src="https://github.com/user-attachments/assets/91dfc79e-26d0-4e33-8ced-a5cbe8433b41" />

- Se corrige el error pero se ha ocultado el botón de Enviar
<img width="1305" height="480" alt="imagen" src="https://github.com/user-attachments/assets/61bea270-2d58-4d2d-9f3b-c2587007d2d3" />


## Comportamiento nuevo

-  El usuario puede corregir las variables del scope, volver a renderizar y enviar el correo sin reiniciar el asistente.

- Error HTML
<img width="1296" height="903" alt="imagen" src="https://github.com/user-attachments/assets/91dfc79e-26d0-4e33-8ced-a5cbe8433b41" />

- Se corrige el error y se vuelve a mostrar el botón de Enviar
<img width="1300" height="661" alt="imagen" src="https://github.com/user-attachments/assets/43437b12-e305-4482-a646-817f4cf6ee8c" />

- Al rellenar los campos obligatorios se cargan los valores no vacíos y, al pulsar el botón de generación de correo, se verifica el campo Destinatario para validar la dirección de correo electrónico. Si es incorrecto se resalta el campo como se muestra en la image y no se genera el contenido del correo.
<img width="1299" height="667" alt="imagen" src="https://github.com/user-attachments/assets/4c74814a-cfde-4a10-b8f1-9a44c8c9a351" />



## Relacionado
- Origen de la tarea: TASK-79311

