### PR TITLE
test comprovar pass py2 i py3

### DIFF
--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -667,8 +667,8 @@ p { color:red;}
             pem_body_text = mailbox_obj.read(cursor, uid, mail_ids[0], ['pem_body_text'])['pem_body_text']
             self.assertEqual(pem_body_text, inlined_html)
 
-    @mock.patch('poweremail.poweremail_mailbox.netsvc.Logger')
-    @mock.patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
+    @patch('poweremail.poweremail_mailbox.netsvc.Logger')
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
     def test_send_this_mail_exception_logs_error(self, mock_send_mail, mock_logger):
         """Test that when send_this_mail raises an exception, the error is logged"""
         with Transaction().start(self.database) as txn:
@@ -693,7 +693,7 @@ p { color:red;}
             
             # Mock send_mail to raise an exception
             mock_send_mail.side_effect = Exception("Connection refused")
-            mock_logger_instance = mock.Mock()
+            mock_logger_instance = Mock()
             mock_logger.return_value = mock_logger_instance
             
             # Send the mail
@@ -712,7 +712,7 @@ p { color:red;}
             # Verify error is in history
             self.assertIn('Traceback', mail['history'])
 
-    @mock.patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
     def test_send_this_mail_failure_historises_error(self, mock_send_mail):
         """Test that when send_mail returns an error message, it's historised"""
         with Transaction().start(self.database) as txn:
@@ -750,7 +750,7 @@ p { color:red;}
             # Verify error message is in history
             self.assertIn(error_message, mail['history'])
 
-    @mock.patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
     def test_send_this_mail_success_moves_to_sent(self, mock_send_mail):
         """Test that when send_mail succeeds, the mail is moved to sent folder"""
         with Transaction().start(self.database) as txn:

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import base64
 import hmac
-from email.base64mime import encode as encode_base64
 
 import six
 if six.PY2:
@@ -863,10 +862,13 @@ p { color:red;}
     def fake_login(self, user, password):
         challenge = b"PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
         challenge = base64.b64decode(challenge)
-        response = (self._to_bytes(user) + b" " + hmac.HMAC(self._to_bytes(password),
-                challenge).hexdigest().encode('ascii')
+        response = (self._to_bytes(user) + b" " +
+                hmac.HMAC(self._to_bytes(password), challenge).hexdigest().encode('ascii')
         )
-        return encode_base64(response, eol="")
+        encoded = base64.b64encode(response)
+        if six.PY3:
+            encoded = encoded.decode('ascii')
+        return encoded
 
     def fake_close(self):
         pass

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import base64
 import hmac
+import qreu
 
 import six
 if six.PY2:
@@ -15,23 +16,22 @@ class TestPoweremailMailbox(testing.OOTestCase):
 
     def create_account(self, cursor, uid, extra_vals=None):
         acc_obj = self.openerp.pool.get('poweremail.core_accounts')
-        imd_obj = self.openerp.pool.get('ir.model.data')
 
-        acc_id = imd_obj.get_object_reference(cursor, uid, 'poweremail', 'info_energia_from_email')[1]
-
-        if not extra_vals:
-            return acc_id
-
-        return acc_obj.copy(cursor, uid, acc_id, extra_vals)
-
-    def create_false_account(self, cursor, uid, extra_vals=None):
         vals = {
-            'smtpserver': '',
-            'smtpport': 0,
+            'name': 'Test account',
+            'user': uid,
+            'email_id': 'test@example.com',
+            'smtpserver': 'smtp.example.com',
+            'smtpport': 587,
+            'smtpuname': 'test',
+            'smtppass': 'test',
+            'company': 'yes'
         }
         if extra_vals:
             vals.update(extra_vals)
-        return self.create_account(cursor, uid, extra_vals=vals)
+
+        acc_id = acc_obj.create(cursor, uid, vals)
+        return acc_id
 
     def create_template(self, cursor, uid, extra_vals=None):
         if extra_vals is None:
@@ -807,26 +807,27 @@ p { color:red;}
 
         El test valida que el fix https://github.com/gisce/qreu/pull/68
         funciona correctament.
-        :return:
         """
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            core_obj = self.pool.get('poweremail.core_accounts')
+            core_obj = self.openerp.pool.get('poweremail.core_accounts')
+            imd_obj = self.openerp.pool.get('ir.model.data')
 
-            acc1_id = self.create_false_account(
-                cursor, uid, extra_vals={
-                    'smtpssl': False,
-                    'smtptls': False,
-                }
-            )
+            acc_id = imd_obj.get_object_reference(cursor, uid, 'poweremail', 'info_energia_from_email')[1]
+            acc1 = core_obj.simple_browse(cursor, uid, acc_id)
 
-            with patch('smtplib.SMTP.login', new=self.fake_login):
-                with patch('smtplib.SMTP.close', new=self.fake_close):
-                    acc1 = core_obj.simple_browse(cursor, uid, acc1_id)
+            acc1.write({
+                'smtpuname': 'test',
+                'smtppass': 'test',
+                'smtpserver': '',
+            })
+            # with patch('qreu.sendcontext.SMTP.login', new=self.fake_login):
+            with patch.object(qreu.sendcontext.SMTP, 'login', side_effect=self.fake_login) as fake_login:
+                with patch('qreu.sendcontext.SMTP.close', new=self.fake_close):
                     # desde l'ERP enviem un unicode a la llibreria qreu
                     self.assertTrue(isinstance(acc1.smtppass, type(u"")))
-                    core_obj.send_mail(cursor, uid, [acc1_id], {
+                    core_obj.send_mail(cursor, uid, [acc_id], {
                             'To': 'a@a.cat',
                             'FROM': 'b@b.cat'
                         },
@@ -835,6 +836,7 @@ p { color:red;}
                             'html': ''
                         }
                     )
+                    fake_login.assert_called_once()
 
     def fake_login(self, user, password):
         """Funció que replica part del comportament de l'autenticació a l'SMTP.

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -16,41 +16,23 @@ class TestPoweremailMailbox(testing.OOTestCase):
 
     def create_account(self, cursor, uid, extra_vals=None):
         acc_obj = self.openerp.pool.get('poweremail.core_accounts')
+        imd_obj = self.openerp.pool.get('ir.model.data')
 
-        vals = {
-            'name': 'Test account',
-            'user': uid,
-            'email_id': 'test@example.com',
-            'smtpserver': 'smtp.example.com',
-            'smtpport': 587,
-            'smtpuname': 'test',
-            'smtppass': 'test',
-            'company': 'yes'
-        }
-        if extra_vals:
-            vals.update(extra_vals)
+        acc_id = imd_obj.get_object_reference(cursor, uid, 'poweremail', 'info_energia_from_email')[1]
 
-        acc_id = acc_obj.create(cursor, uid, vals)
-        return acc_id
+        if not extra_vals:
+            return acc_id
+
+        return acc_obj.copy(cursor, uid, acc_id, extra_vals)
 
     def create_false_account(self, cursor, uid, extra_vals=None):
-        acc_obj = self.openerp.pool.get('poweremail.core_accounts')
-
         vals = {
-            'name': 'Test account',
-            'user': uid,
-            'email_id': 'test@example.com',
             'smtpserver': '',
             'smtpport': 0,
-            'smtpuname': 'test',
-            'smtppass': 'test',
-            'company': 'yes'
         }
         if extra_vals:
             vals.update(extra_vals)
-
-        acc_id = acc_obj.create(cursor, uid, vals)
-        return acc_id
+        return self.create_account(cursor, uid, extra_vals=vals)
 
     def create_template(self, cursor, uid, extra_vals=None):
         if extra_vals is None:
@@ -823,8 +805,6 @@ p { color:red;}
         # Aquest test el que farà serà comprovar la funcionalitat del get_sender
         # El problema que tenim ara mateix és que a l'hora de fer el get_sender,
         # aquest mira de crear un Sender o un SMTPSender.
-        self.openerp.install_module('base_extended')
-
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -1,6 +1,13 @@
 # coding=utf-8
 import base64
-import mock
+import hmac
+from email.base64mime import encode as encode_base64
+
+import six
+if six.PY2:
+    from mock import MagicMock, PropertyMock, patch, Mock
+else:
+    from unittest.mock import MagicMock, PropertyMock, patch, Mock
 from destral import testing
 from destral.transaction import Transaction
 
@@ -16,6 +23,25 @@ class TestPoweremailMailbox(testing.OOTestCase):
             'email_id': 'test@example.com',
             'smtpserver': 'smtp.example.com',
             'smtpport': 587,
+            'smtpuname': 'test',
+            'smtppass': 'test',
+            'company': 'yes'
+        }
+        if extra_vals:
+            vals.update(extra_vals)
+
+        acc_id = acc_obj.create(cursor, uid, vals)
+        return acc_id
+
+    def create_false_account(self, cursor, uid, extra_vals=None):
+        acc_obj = self.openerp.pool.get('poweremail.core_accounts')
+
+        vals = {
+            'name': 'Test account',
+            'user': uid,
+            'email_id': 'test@example.com',
+            'smtpserver': '',
+            'smtpport': 0,
             'smtpuname': 'test',
             'smtppass': 'test',
             'company': 'yes'
@@ -200,7 +226,7 @@ class TestPoweremailMailbox(testing.OOTestCase):
             attach_ids = ir_attachment_obj.search(cursor, uid, [])
             self.assertEqual(len(attach_ids), 2)
 
-    @mock.patch('poweremail.poweremail_template.poweremail_templates.create_report')
+    @patch('poweremail.poweremail_template.poweremail_templates.create_report')
     def generate_mail_with_attachments_and_report(self, mock_function):
         with Transaction().start(self.database) as txn:
             uid = txn.user
@@ -264,7 +290,7 @@ class TestPoweremailMailbox(testing.OOTestCase):
             attach_ids = ir_attachment_obj.search(cursor, uid, [])
             self.assertEqual(len(attach_ids), 3)
 
-    @mock.patch('poweremail.poweremail_template.poweremail_templates.create_report')
+    @patch('poweremail.poweremail_template.poweremail_templates.create_report')
     def generate_mail_with_report_no_attachments(self, mock_function):
         with Transaction().start(self.database) as txn:
             uid = txn.user
@@ -316,7 +342,7 @@ class TestPoweremailMailbox(testing.OOTestCase):
             attach_ids = ir_attachment_obj.search(cursor, uid, [])
             self.assertEqual(len(attach_ids), 1)
 
-    @mock.patch('poweremail.poweremail_template.poweremail_templates.create_report')
+    @patch('poweremail.poweremail_template.poweremail_templates.create_report')
     def generate_mail_with_attachments_and_report_multi_users(self, mock_function):
         with Transaction().start(self.database) as txn:
             uid = txn.user
@@ -391,11 +417,11 @@ class TestPoweremailMailbox(testing.OOTestCase):
             attach_ids = ir_attachment_obj.search(cursor, uid, [])
             self.assertEqual(len(attach_ids), 5)
 
-    @mock.patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_template_attachments')
-    @mock.patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_attachment_documents')
-    @mock.patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.process_extra_attachment_in_template')
-    @mock.patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_report_attachment')
-    @mock.patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_mail')
+    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_template_attachments')
+    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_attachment_documents')
+    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.process_extra_attachment_in_template')
+    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_report_attachment')
+    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_mail')
     def test_save_to_mailbox(self, mock_function, mock_function_2, mock_function_3, mock_function_4, mock_function_5):
         with Transaction().start(self.database) as txn:
             uid = txn.user
@@ -640,3 +666,46 @@ p { color:red;}
             mail_ids = send_wizard_obj.save_to_mailbox(cursor, uid, [wizard_id], context=context)
             pem_body_text = mailbox_obj.read(cursor, uid, mail_ids[0], ['pem_body_text'])['pem_body_text']
             self.assertEqual(pem_body_text, inlined_html)
+
+    def test_check_poweremail_get_sender(self):
+        # Aquest test el que farà serà comprovar la funcionalitat del get_sender
+        # El problema que tenim ara mateix és que a l'hora de fer el get_sender,
+        # aquest mira de crear un Sender o un SMTPSender.
+        self.openerp.install_module('base_extended')
+
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            core_obj = self.pool.get('poweremail.core_accounts')
+
+            acc1_id = self.create_false_account(
+                cursor, uid, extra_vals={
+                    'name': 'acc1',
+                    'email_id': 'test1@example.com',
+                    'smtpssl': False,
+                    'smtptls': False,
+                }
+            )
+
+            with patch('smtplib.SMTP.login', new=self.fake_login):
+                with patch('smtplib.SMTP.close', new=self.fake_close):
+                    core_obj.send_mail(cursor, uid, [acc1_id], {
+                            'To': 'nvillarroya@gisce.net',
+                            'CC': '',
+                            'BCC': '',
+                            'FROM': 'nvillarroya@gisce.net'
+                        },
+                        "Prova", {
+                            'text': "Això és una prova",
+                            'html': ''
+                        }
+                    )
+
+    def fake_login(self, user, password):
+        challenge = "PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
+        challenge = base64.decodestring(challenge)
+        response = user + " " + hmac.HMAC(password, challenge).hexdigest()
+        return encode_base64(response, eol="")
+
+    def fake_close(self):
+        pass

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -800,7 +800,7 @@ p { color:red;}
             # Verify error message is in history
             self.assertIn('No recipient', mail['history'])
     
-    def test_check_poweremail_get_sender(self):
+    def test_send_mail_cram_md5_login_casts_password_to_unicode(self):
         """
         Test que comprova que es pot autenticar correctament
         amb el mode CRAM-MD5 al moment de fer login a l'SMTP.

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import base64
 import hmac
+import hashlib
 
 import six
 if six.PY2:
@@ -838,6 +839,7 @@ p { color:red;}
                 }
             )
 
+            context = {'lang': 'en_US'}
             with patch('smtplib.SMTP.login', new=self.fake_login):
                 with patch('smtplib.SMTP.close', new=self.fake_close):
                     core_obj.send_mail(cursor, uid, [acc1_id], {
@@ -849,7 +851,8 @@ p { color:red;}
                         "Prova", {
                             'text': "Això és una prova",
                             'html': ''
-                        }
+                        },
+                        context=context
                     )
 
     def _to_bytes(self, value, encoding='utf-8'):
@@ -862,8 +865,13 @@ p { color:red;}
     def fake_login(self, user, password):
         challenge = b"PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
         challenge = base64.b64decode(challenge)
-        response = (self._to_bytes(user) + b" " +
-                hmac.HMAC(self._to_bytes(password), challenge).hexdigest().encode('ascii')
+        response = (
+                self._to_bytes(user) + b" " +
+                hmac.new(
+                    self._to_bytes(password),
+                    challenge,
+                    hashlib.md5
+                ).hexdigest().encode('ascii')
         )
         encoded = base64.b64encode(response)
         if six.PY3:

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -820,11 +820,14 @@ p { color:red;}
             self.assertIn('No recipient', mail['history'])
     
     def test_check_poweremail_get_sender(self):
-        # Aquest test el que farà serà comprovar la funcionalitat del get_sender
-        # El problema que tenim ara mateix és que a l'hora de fer el get_sender,
-        # aquest mira de crear un Sender o un SMTPSender.
-        self.openerp.install_module('base_extended')
+        """
+        Test que comprova que es pot autenticar correctament
+        amb el mode CRAM-MD5 al moment de fer login a l'SMTP.
 
+        El test valida que el fix https://github.com/gisce/qreu/pull/68
+        funciona correctament.
+        :return:
+        """
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
@@ -832,51 +835,50 @@ p { color:red;}
 
             acc1_id = self.create_false_account(
                 cursor, uid, extra_vals={
-                    'name': 'acc1',
-                    'email_id': 'test1@example.com',
                     'smtpssl': False,
                     'smtptls': False,
                 }
             )
 
-            context = {'lang': 'en_US'}
             with patch('smtplib.SMTP.login', new=self.fake_login):
                 with patch('smtplib.SMTP.close', new=self.fake_close):
+                    acc1 = core_obj.simple_browse(cursor, uid, acc1_id)
+                    # desde l'ERP enviem un unicode a la llibreria qreu
+                    self.assertTrue(isinstance(acc1.smtppass, type(u"")))
                     core_obj.send_mail(cursor, uid, [acc1_id], {
-                            'To': 'nvillarroya@gisce.net',
-                            'CC': '',
-                            'BCC': '',
-                            'FROM': 'nvillarroya@gisce.net'
+                            'To': 'a@a.cat',
+                            'FROM': 'b@b.cat'
                         },
-                        "Prova", {
-                            'text': "Això és una prova",
+                        "Test", {
+                            'text': "Test",
                             'html': ''
-                        },
-                        context=context
+                        }
                     )
 
-    def _to_bytes(self, value, encoding='utf-8'):
-        if value is None:
-            return b''
-        if isinstance(value, bytes):
-            return value
-        return value.encode(encoding)
-
     def fake_login(self, user, password):
-        challenge = b"PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
-        challenge = base64.b64decode(challenge)
-        response = (
-                self._to_bytes(user) + b" " +
-                hmac.new(
-                    self._to_bytes(password),
-                    challenge,
-                    hashlib.md5
-                ).hexdigest().encode('ascii')
-        )
-        encoded = base64.b64encode(response)
-        if six.PY3:
-            encoded = encoded.decode('ascii')
-        return encoded
+        """Funció que replica part del comportament de l'autenticació a l'SMTP.
+        Realment no replica el login, només la part en que ens interessa per
+        validar el test_check_poweremail_get_sender
+        - Python 3: auth_cram_md5
+        - Python 2: encode_cram_md5
+        """
+        # abans del fix https://github.com/gisce/qreu/pull/68 password era
+        # unicode i petava. Amb el fix, es força un casting i hauria d'arribar
+        # un string
+        self.assertTrue(isinstance(password, str))
+        if six.PY2:
+            # replica el comportament de smtplib.SMTP.login.encode_cram_md5
+            from email.base64mime import encode as encode_base64
+            challenge = "PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
+            challenge = base64.decodestring(challenge)
+            response = user + " " + hmac.HMAC(password, challenge).hexdigest()
+            return encode_base64(response, eol="")
+        else:
+            # replica el comportament de smtplib.SMTP.auth_cram_md5
+            challenge = b"PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
+            if challenge is None:
+                return None
+            return user + " " + hmac.HMAC(password.encode('ascii'), challenge, 'md5').hexdigest()
 
     def fake_close(self):
         pass

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 import base64
 import hmac
-import hashlib
 
 import six
 if six.PY2:
-    from mock import MagicMock, PropertyMock, patch, Mock
+    from mock import patch, Mock
 else:
-    from unittest.mock import MagicMock, PropertyMock, patch, Mock
+    from unittest.mock import patch, Mock
 from destral import testing
 from destral.transaction import Transaction
 

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -853,10 +853,19 @@ p { color:red;}
                         }
                     )
 
+    def _to_bytes(self, value, encoding='utf-8'):
+        if value is None:
+            return b''
+        if isinstance(value, bytes):
+            return value
+        return value.encode(encoding)
+
     def fake_login(self, user, password):
-        challenge = "PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
-        challenge = base64.decodestring(challenge)
-        response = user + " " + hmac.HMAC(password, challenge).hexdigest()
+        challenge = b"PDE3MjgzOTEwMjMuNDU2N0BtYWlsLmV4YW1wbGUuY29tPg=="
+        challenge = base64.b64decode(challenge)
+        response = (self._to_bytes(user) + b" " + hmac.HMAC(self._to_bytes(password),
+                challenge).hexdigest().encode('ascii')
+        )
         return encode_base64(response, eol="")
 
     def fake_close(self):


### PR DESCRIPTION
# New behavior
The solution applied is to directly cast the password to a string. This way, the error no longer occurs, neither in Python 2 nor in Python 3.

We've created a test to validate it.

# Old behavior
When establishing the connection with the SMTP or SMTPSSL server, the code performs a check that uses the password.

In Python 2, the password is a Unicode value, which causes an error during this check because a string is expected.

# Checklist
- [x] Tests (if not implemented, explain why)

# Related
- [x] Related PR: https://github.com/gisce/qreu/pull/68
- [x] TASK-82507
