### PR TITLE
Move get extra attachment function to poweremail template

### DIFF
--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -341,38 +341,6 @@ class poweremail_send_wizard(osv.osv_memory):
             return attachment_id
         return False
 
-    def process_extra_attachment_in_template(self, cr, uid, template, src_rec_id, mail_id, data, context=None):
-        if context is None:
-            context = {}
-
-        attach_obj = self.pool.get('ir.attachment')
-
-        attachment_ids = []
-        # For each extra attachment in template
-        for tmpl_attach in template.tmpl_attachment_ids:
-            report = tmpl_attach.report_id
-            reportname = 'report.%s' % report.report_name
-            data['model'] = report.model
-            model_obj = self.pool.get(report.model)
-            # Parse search params
-            search_params = eval(self.get_value(cr, uid, template, tmpl_attach.search_params,context, src_rec_id))
-            report_model_ids = model_obj.search(cr, uid, search_params, context=context)
-            file_name = self.get_value(cr, uid, template, tmpl_attach.file_name, context, src_rec_id)
-            if report_model_ids:
-                service = netsvc.LocalService(reportname)
-                (result, format) = service.create(cr, uid, report_model_ids, data, context=context)
-                attach_vals = {
-                    'name': file_name,
-                    'datas': base64.b64encode(result),
-                    'datas_fname': file_name,
-                    'description': _("No Description"),
-                    'res_model': 'poweremail.mailbox',
-                    'res_id': mail_id
-                }
-                attachment_id = attach_obj.create(cr, uid, attach_vals, context=context)
-                attachment_ids.append(attachment_id)
-        return attachment_ids
-
     def add_attachment_documents(self, cr, uid, screen_vals, mail_id, context=None):
         if context is None:
             context = {}
@@ -526,7 +494,7 @@ class poweremail_send_wizard(osv.osv_memory):
             if attachment_id:
                 attachment_ids.append(attachment_id)
             data = {}
-            attachment_ids_extra = self.process_extra_attachment_in_template(
+            attachment_ids_extra = template_o.process_extra_attachment_in_template(
                 cr, uid, template, src_rec_id, mail_id, data, context=ctx
             )
             attachment_ids.extend(attachment_ids_extra)

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1234,7 +1234,7 @@ class poweremail_templates(osv.osv):
             attachment_ids.extend(attachment_ids_extra)
 
             mailbox_vals = {
-                'pem_attachments_ids': [[6, 0, [attachment_ids]]],
+                'pem_attachments_ids': [[6, 0, attachment_ids]],
                 'mail_type': 'multipart/mixed'
             }
             res = mailbox_obj.write(cursor, user, mail.id, mailbox_vals, context=context)

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1212,6 +1212,7 @@ class poweremail_templates(osv.osv):
         dynamic_attachment = self.get_dynamic_attachment(cursor, user, template, record_ids, context=context)
 
         if dynamic_attachment:
+            attachment_ids = []
             new_att_vals = {
                 'name': mail.pem_subject + ' (Email Attachment)',
                 'datas': dynamic_attachment.get('file', ''),
@@ -1223,8 +1224,17 @@ class poweremail_templates(osv.osv):
                 'res_id': mail.id
             }
             attachment_id = attachment_obj.create(cursor, user, new_att_vals, context=context)
+            if attachment_id:
+                attachment_ids.append(attachment_id)
+
+            data = {}
+            attachment_ids_extra = self.process_extra_attachment_in_template(
+                cursor, user, template, record_ids[0], mail.id, data, context=context
+            )
+            attachment_ids.extend(attachment_ids_extra)
+
             mailbox_vals = {
-                'pem_attachments_ids': [[6, 0, [attachment_id]]],
+                'pem_attachments_ids': [[6, 0, [attachment_ids]]],
                 'mail_type': 'multipart/mixed'
             }
             res = mailbox_obj.write(cursor, user, mail.id, mailbox_vals, context=context)
@@ -1591,6 +1601,39 @@ class poweremail_templates(osv.osv):
             'url': url,
             'target': 'new',
         }
+
+    def process_extra_attachment_in_template(self, cr, uid, template, src_rec_id, mail_id, data, context=None):
+        if context is None:
+            context = {}
+
+        attach_obj = self.pool.get('ir.attachment')
+
+        attachment_ids = []
+        # For each extra attachment in template
+        for tmpl_attach in template.tmpl_attachment_ids:
+            report = tmpl_attach.report_id
+            reportname = 'report.%s' % report.report_name
+            data['model'] = report.model
+            model_obj = self.pool.get(report.model)
+            # Parse search params
+            search_params = eval(get_value(cr, uid, src_rec_id, tmpl_attach.search_params, template, context=context))
+            report_model_ids = model_obj.search(cr, uid, search_params, context=context)
+            file_name = get_value(cr, uid, src_rec_id, tmpl_attach.file_name, template, context)
+            if report_model_ids:
+                service = netsvc.LocalService(reportname)
+                (result, format) = service.create(cr, uid, report_model_ids, data, context=context)
+                attach_vals = {
+                    'name': file_name,
+                    'datas': base64.b64encode(result),
+                    'datas_fname': file_name,
+                    'description': _("No Description"),
+                    'res_model': 'poweremail.mailbox',
+                    'res_id': mail_id
+                }
+                attachment_id = attach_obj.create(cr, uid, attach_vals, context=context)
+                attachment_ids.append(attachment_id)
+        return attachment_ids
+
 
 poweremail_templates()
 

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -400,7 +400,7 @@ class TestPoweremailMailbox(testing.OOTestCase):
 
     @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_template_attachments')
     @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.add_attachment_documents')
-    @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.process_extra_attachment_in_template')
+    @patch('poweremail.poweremail_template.poweremail_templates.process_extra_attachment_in_template')
     @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_report_attachment')
     @patch('poweremail.poweremail_send_wizard.poweremail_send_wizard.create_mail')
     def test_save_to_mailbox(self, mock_function, mock_function_2, mock_function_3, mock_function_4, mock_function_5):

--- a/tests/test_poweremail_templates.py
+++ b/tests/test_poweremail_templates.py
@@ -424,3 +424,48 @@ p { color:red;}
             key=lambda tmpl_id: values[tmpl_id]['last_send_date'] or '1970-01-01 00:00:00'
         )
         self.assertEqual(ordered_by_last_send_date, [tmpl_0_id, tmpl_1_id, tmpl_2_id])
+
+    @mock.patch('poweremail.poweremail_template.netsvc.LocalService')
+    @mock.patch('poweremail.poweremail_template.get_value')
+    def test_process_extra_attachment_in_template(self, mock_get_value, mock_local_service):
+        tmpl_obj = self.openerp.pool.get('poweremail.templates')
+        cursor = self.cursor
+        uid = self.uid
+
+        src_rec_id = 99
+        mail_id = 100
+
+        class MockReport(object):
+            report_name = 'test_report'
+            model = 'res.partner'
+
+        class MockTmplAttach(object):
+            report_id = MockReport()
+            search_params = "'search_params'"
+            file_name = "'output.pdf'"
+
+        class MockTemplate(object):
+            tmpl_attachment_ids = [MockTmplAttach()]
+
+        template = MockTemplate()
+
+        mock_get_value.side_effect = ["[]", "my_file_name.pdf"]
+
+        mock_service_instance = mock.Mock()
+        mock_local_service.return_value = mock_service_instance
+        mock_service_instance.create.return_value = (b'pdf_content', 'pdf')
+
+        with mock.patch.object(self.openerp.pool.get('res.partner'), 'search', return_value=[1, 2]):
+            with mock.patch.object(self.openerp.pool.get('ir.attachment'), 'create', return_value=123) as mock_attach_create:
+                data = {}
+                attachment_ids = tmpl_obj.process_extra_attachment_in_template(
+                    cursor, uid, template, src_rec_id, mail_id, data
+                )
+
+                self.assertEqual(attachment_ids, [123])
+                mock_attach_create.assert_called_once()
+                call_args = mock_attach_create.call_args
+                self.assertEqual(call_args[0][2]['name'], 'my_file_name.pdf')
+                self.assertEqual(call_args[0][2]['datas_fname'], 'my_file_name.pdf')
+                self.assertEqual(call_args[0][2]['res_model'], 'poweremail.mailbox')
+                self.assertEqual(call_args[0][2]['res_id'], mail_id)


### PR DESCRIPTION
# New behavior
Move get extra attachment function to poweremail template for generic use.

# Old behavior
The extra attachment function was on the send wizard.

# Checklist

- [x] Tests
- [ ] Document new behaviour if necessary (RFC forum)

# Related

- [x] TASK-87495
