### PR TITLE
Send mailbox image attachments inline

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -522,6 +522,7 @@ class poweremail_core_accounts(osv.osv):
     def send_mail(self, cr, uid, ids,
                   addresses, subject='', body=None, payload=None, context=None):
         def create_qreu(headers, payload, **kwargs):
+            has_inline_attachment = False
             mail = Email(**{
                 'subject': kwargs.get('subject'),
                 'from': kwargs.get('from'),
@@ -535,15 +536,35 @@ class poweremail_core_accounts(osv.osv):
                 mail.add_header(header, value)
             # Add all attachments (if any)
             for file_name in payload.keys():
+                attachment_payload = payload[file_name]
+                attachment_kwargs = {}
+                if isinstance(attachment_payload, dict):
+                    attachment_data = attachment_payload.get('datas', '')
+                    disposition = attachment_payload.get(
+                        'disposition', 'attachment'
+                    )
+                    content_id = attachment_payload.get('content_id')
+                    attachment_kwargs.update({
+                        'disposition': disposition,
+                        'content_id': content_id,
+                    })
+                    has_inline_attachment = (
+                        has_inline_attachment or disposition == 'inline'
+                    )
+                else:
+                    attachment_data = attachment_payload
                 # Decode b64 from raw base64 attachment and write it to a buffer
                 attachment_buffer = StringIO()
                 attachment_buffer.write(
-                    base64.b64decode(payload[file_name]))
+                    base64.b64decode(attachment_data))
                 mail.add_attachment(
                     input_buff=attachment_buffer,
-                    attname=file_name
+                    attname=file_name,
+                    **attachment_kwargs
                 )
                 del attachment_buffer
+            if has_inline_attachment:
+                mail.email.set_type('multipart/related')
             return mail
 
         def parse_body_html(pem_body_html, pem_body_text):

--- a/poweremail_mailbox.py
+++ b/poweremail_mailbox.py
@@ -42,6 +42,11 @@ import qreu
 
 LOGGER = netsvc.Logger()
 
+INLINE_IMAGE_RE = re.compile(
+    r'(<img\b[^>]*\bsrc=["\'])attachment://(\d+)(["\'][^>]*>)',
+    re.IGNORECASE | re.UNICODE
+)
+
 class PoweremailMailbox(osv.osv):
     _name = "poweremail.mailbox"
     _description = 'Power Email Mailbox included all type inbox,outbox,junk..'
@@ -174,6 +179,38 @@ class PoweremailMailbox(osv.osv):
             context = {}
         core_obj = self.pool.get('poweremail.core_accounts')
         conv_obj = self.pool.get('poweremail.conversation')
+
+        def inline_content_id(attachment_id):
+            return 'poweremail-attachment-{0}@local'.format(attachment_id)
+
+        def inline_attachment_ids(body_html, attachment_ids):
+            if not body_html:
+                return []
+            attachment_ids = set(attachment_ids)
+            res = []
+            for attachment_id in INLINE_IMAGE_RE.findall(body_html):
+                attachment_id = int(attachment_id[1])
+                if attachment_id in attachment_ids and attachment_id not in res:
+                    res.append(attachment_id)
+            return res
+
+        def replace_inline_sources(body_html, inline_ids):
+            if not body_html or not inline_ids:
+                return body_html
+            inline_ids = set(inline_ids)
+
+            def replace(match):
+                attachment_id = int(match.group(2))
+                if attachment_id not in inline_ids:
+                    return match.group(0)
+                return '{0}cid:{1}{2}'.format(
+                    match.group(1),
+                    inline_content_id(attachment_id),
+                    match.group(3)
+                )
+
+            return INLINE_IMAGE_RE.sub(replace, body_html)
+
         for id in ids:
             try:
                 context['headers'] = {}
@@ -186,6 +223,25 @@ class PoweremailMailbox(osv.osv):
                                    context, error=True)
                     continue
                 payload = {}
+                inline_ids = set(
+                    context.get('inline_attachment_ids', [])
+                )
+                inline_content_ids = context.get(
+                    'inline_attachment_content_ids', {}
+                )
+                body_inline_attachment_ids = inline_attachment_ids(
+                    values.get('pem_body_html') or '',
+                    values.get('pem_attachments_ids') or []
+                )
+                for attid in body_inline_attachment_ids:
+                    inline_ids.add(attid)
+                    inline_content_ids.setdefault(attid, inline_content_id(attid))
+                for attid in inline_ids:
+                    inline_content_ids.setdefault(attid, inline_content_id(attid))
+                pem_body_html = replace_inline_sources(
+                    values.get('pem_body_html') or '',
+                    body_inline_attachment_ids
+                )
                 if values['pem_attachments_ids']:
                     #Get filenames & binary of attachments
                     for attid in values['pem_attachments_ids']:
@@ -196,7 +252,16 @@ class PoweremailMailbox(osv.osv):
                             att_name = "%s%d" % ( attachment.datas_fname or attachment.name, counter )
                             counter += 1
                         att_name = att_name.replace("/", "-")
-                        payload[att_name] = attachment.datas
+                        if attid in inline_ids:
+                            payload[att_name] = {
+                                'datas': attachment.datas,
+                                'disposition': 'inline',
+                                'content_id': inline_content_ids.get(
+                                    attid, inline_content_ids.get(str(attid))
+                                ),
+                            }
+                        else:
+                            payload[att_name] = attachment.datas
                 if values['conversation_id']:
                     mails = conv_obj.browse(cr, uid,
                                             values['conversation_id'][0]).mails
@@ -237,7 +302,7 @@ class PoweremailMailbox(osv.osv):
                     },
                     values['pem_subject'] or u'', {
                         'text': values.get('pem_body_text') or u'',
-                        'html': values.get('pem_body_html') or u''
+                        'html': pem_body_html
                     }, payload=payload, context=ctx
                 )
                 if result == True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mako
-qreu>=0.16.2
+qreu>=0.7.5
 html2text
 premailer==2.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mako
-qreu>=0.7.5
+qreu>=0.16.2
 html2text
 premailer==2.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mako
-qreu>=0.7.5
+qreu>=0.17.0
 html2text
 premailer==2.9.6

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -768,6 +768,54 @@ p { color:red;}
             # Verify success message is in history
             self.assertIn('Email sent successfully', mail['history'])
 
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.send_mail')
+    def test_send_this_mail_marks_body_image_attachments_inline(self, mock_send_mail):
+        """Test mailbox HTML attachment images are propagated inline."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+            attachment_obj = self.openerp.pool.get('ir.attachment')
+
+            acc_id = self.create_account(cursor, uid)
+            attachment_id = attachment_obj.create(cursor, uid, {
+                'datas_fname': 'logo.png',
+                'name': 'logo.png',
+                'datas': base64.b64encode(b'testContent').decode('ascii'),
+            })
+            mail_id = mailbox_obj.create(cursor, uid, {
+                'pem_from': 'test@example.com',
+                'pem_to': 'recipient@example.com',
+                'pem_subject': 'Test email',
+                'pem_body_text': 'Test body',
+                'pem_body_html': (
+                    '<p>Test</p><img src="attachment://{0}" />'.format(
+                        attachment_id
+                    )
+                ),
+                'pem_account_id': acc_id,
+                'folder': 'outbox',
+                'state': 'na',
+                'pem_attachments_ids': [(6, 0, [attachment_id])],
+            })
+            mock_send_mail.return_value = True
+
+            mailbox_obj.send_this_mail(cursor, uid, [mail_id])
+
+            body = mock_send_mail.call_args[0][5]
+            payload = mock_send_mail.call_args[1]['payload']
+            self.assertEqual(payload['logo.png']['disposition'], 'inline')
+            self.assertEqual(
+                payload['logo.png']['content_id'],
+                'poweremail-attachment-{0}@local'.format(attachment_id)
+            )
+            self.assertIn(
+                'src="cid:poweremail-attachment-{0}@local"'.format(
+                    attachment_id
+                ),
+                body['html']
+            )
+
     def test_send_this_mail_no_recipient_error(self):
         """Test that when there's no recipient, an appropriate error is logged"""
         with Transaction().start(self.database) as txn:


### PR DESCRIPTION
## Summary
- Detect mailbox HTML images that reference `attachment://<id>` and only inline them when that attachment belongs to the mailbox.
- Rewrite those image sources to `cid:` and pass inline metadata through the existing payload path.
- Teach `poweremail.core_accounts.send_mail` to accept structured payload entries while preserving the legacy `filename -> base64` payload format.
- Require `qreu>=0.17.0`, the release carrying the inline attachment API.

## Related
- Depends on the inline attachment API released in `qreu` v0.17.0: https://pypi.org/project/qreu/0.17.0/
- Supports gisce/crm_poweremail#85 without CRM-specific MIME overrides.

## Tests
- `/home/openclaw/.pyenv/versions/erp2/bin/python -m py_compile poweremail_core.py poweremail_mailbox.py tests/test_poweremail_mailbox.py`
- Attempted focused Destral selectors, but this local Destral loader did not resolve test classes through `-t`; full-module runs were stopped after hanging silently under `--quiet`.
