### PR TITLE
TASK-91250 Validate email headers before sending

### DIFF
--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -562,12 +562,19 @@ class poweremail_core_accounts(osv.osv):
                 not address or '@' not in address or
                 address.startswith('@') or address.endswith('@') or
                 any(char.isspace() for char in address) or
-                any(ord(char) < 33 for char in address)
+                any(ord(char) < 33 for char in address) or
+                not self._has_valid_email_domain(address)
             ):
                 return _("Header \"{}\" contains an invalid email address: {}").format(
                     header, tools.ustr(item)
                 )
         return False
+
+    def _has_valid_email_domain(self, address):
+        domain = address.rsplit('@', 1)[1]
+        if '.' not in domain or domain.startswith('.') or domain.endswith('.'):
+            return False
+        return all(part for part in domain.split('.'))
 
     def _validate_mail_headers(self, headers):
         for name, value in headers:

--- a/poweremail_core.py
+++ b/poweremail_core.py
@@ -519,6 +519,75 @@ class poweremail_core_accounts(osv.osv):
         )
         return sender
 
+    def _validate_header_name(self, name):
+        if not name:
+            return _("Header name must not be empty")
+        name = tools.ustr(name)
+        if ':' in name or '\r' in name or '\n' in name:
+            return _("Header name contains invalid characters")
+        if any(ord(char) < 33 or ord(char) > 126 for char in name):
+            return _("Header name must contain only printable ASCII characters")
+        return False
+
+    def _validate_header_value(self, name, value):
+        if value in (None, False):
+            return False
+        if isinstance(value, (list, tuple, set)):
+            values = value
+        else:
+            values = [value]
+        for item in values:
+            if item in (None, False):
+                continue
+            item = tools.ustr(item)
+            if '\r' in item or '\n' in item:
+                return _("Header \"{}\" contains a line break").format(name)
+        return False
+
+    def _format_header_name(self, name):
+        return tools.ustr(name).replace('\r', '\\r').replace('\n', '\\n')
+
+    def _validate_email_address(self, header, value):
+        if value in (None, False, ''):
+            return False
+        if isinstance(value, (list, tuple, set)):
+            values = value
+        else:
+            values = [value]
+        for item in values:
+            if item in (None, False, ''):
+                continue
+            _display_name, address = parseaddr(tools.ustr(item))
+            if (
+                not address or '@' not in address or
+                address.startswith('@') or address.endswith('@') or
+                any(char.isspace() for char in address) or
+                any(ord(char) < 33 for char in address)
+            ):
+                return _("Header \"{}\" contains an invalid email address: {}").format(
+                    header, tools.ustr(item)
+                )
+        return False
+
+    def _validate_mail_headers(self, headers):
+        for name, value in headers:
+            error = self._validate_header_name(name)
+            if error:
+                return _("Invalid email header \"{}\": {}").format(
+                    self._format_header_name(name), error
+                )
+            error = self._validate_header_value(name, value)
+            if error:
+                return error
+        return False
+
+    def _validate_mail_addresses(self, headers):
+        for name, value in headers:
+            error = self._validate_email_address(name, value)
+            if error:
+                return error
+        return False
+
     def send_mail(self, cr, uid, ids,
                   addresses, subject='', body=None, payload=None, context=None):
         def create_qreu(headers, payload, **kwargs):
@@ -640,6 +709,29 @@ class poweremail_core_accounts(osv.osv):
                 })
             elif 'Organitzation' in extra_headers:
                 extra_headers.pop('Organitzation')
+            invalid_header = self._validate_mail_headers([
+                ('Subject', subject),
+                ('From', sender_name),
+                ('To', addresses_list.get('To', [])),
+                ('Cc', addresses_list.get('CC', [])),
+                ('Bcc', addresses_list.get('BCC', [])),
+            ] + list(extra_headers.items()))
+            if invalid_header:
+                logger.notifyChannel(
+                    _("Power Email"), netsvc.LOG_ERROR, invalid_header
+                )
+                return invalid_header
+            invalid_address = self._validate_mail_addresses([
+                ('From', sender_name),
+                ('To', addresses_list.get('To', [])),
+                ('Cc', addresses_list.get('CC', [])),
+                ('Bcc', addresses_list.get('BCC', [])),
+            ])
+            if invalid_address:
+                logger.notifyChannel(
+                    _("Power Email"), netsvc.LOG_ERROR, invalid_address
+                )
+                return invalid_address
             # Use sender if debug is set
             sender = (Sender if config.get('debug_mode', False) else SMTPSender)
             with self.get_sender(account): # Returns a Sender context from qreu

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -847,6 +847,90 @@ p { color:red;}
             
             # Verify error message is in history
             self.assertIn('No recipient', mail['history'])
+
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.get_sender')
+    def test_send_this_mail_invalid_subject_header_error(self, mock_get_sender):
+        """Invalid subject headers are rejected before opening SMTP."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+
+            acc_id = self.create_account(cursor, uid)
+            mail_id = mailbox_obj.create(cursor, uid, {
+                'pem_from': 'test@example.com',
+                'pem_to': 'recipient@example.com',
+                'pem_subject': 'Test email\nInjected: yes',
+                'pem_body_text': 'Test body',
+                'pem_account_id': acc_id,
+                'folder': 'outbox',
+                'state': 'na',
+            })
+
+            mailbox_obj.send_this_mail(cursor, uid, [mail_id])
+
+            mail = mailbox_obj.read(
+                cursor, uid, mail_id, ['folder', 'history', 'state']
+            )
+            self.assertEqual(mail['folder'], 'error')
+            self.assertEqual(mail['state'], 'na')
+            self.assertIn('Header "Subject" contains a line break', mail['history'])
+            self.assertFalse(mock_get_sender.called)
+
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.get_sender')
+    def test_send_this_mail_invalid_recipient_header_error(self, mock_get_sender):
+        """Invalid recipient addresses are rejected before opening SMTP."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+
+            acc_id = self.create_account(cursor, uid)
+            mail_id = mailbox_obj.create(cursor, uid, {
+                'pem_from': 'test@example.com',
+                'pem_to': 'invalid-recipient',
+                'pem_subject': 'Test email',
+                'pem_body_text': 'Test body',
+                'pem_account_id': acc_id,
+                'folder': 'outbox',
+                'state': 'na',
+            })
+
+            mailbox_obj.send_this_mail(cursor, uid, [mail_id])
+
+            mail = mailbox_obj.read(
+                cursor, uid, mail_id, ['folder', 'history', 'state']
+            )
+            self.assertEqual(mail['folder'], 'error')
+            self.assertEqual(mail['state'], 'na')
+            self.assertIn(
+                'Header "To" contains an invalid email address',
+                mail['history']
+            )
+            self.assertFalse(mock_get_sender.called)
+
+    def test_send_mail_invalid_extra_header_error(self):
+        """Invalid custom headers return a clear error instead of sending."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            core_obj = self.openerp.pool.get('poweremail.core_accounts')
+
+            acc_id = self.create_account(cursor, uid)
+            result = core_obj.send_mail(
+                cursor, uid, [acc_id], {
+                    'To': 'recipient@example.com',
+                    'FROM': 'test@example.com'
+                },
+                'Test email', {
+                    'text': 'Test body',
+                    'html': ''
+                },
+                context={'headers': {'X-Test\nInjected': 'value'}}
+            )
+
+            self.assertIn('Invalid email header "X-Test\\nInjected"', result)
+            self.assertIn('Header name contains invalid characters', result)
     
     def test_send_mail_cram_md5_login_casts_password_to_unicode(self):
         """

--- a/tests/test_poweremail_mailbox.py
+++ b/tests/test_poweremail_mailbox.py
@@ -909,6 +909,74 @@ p { color:red;}
             )
             self.assertFalse(mock_get_sender.called)
 
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.get_sender')
+    def test_send_this_mail_recipient_domain_without_dot_error(
+        self, mock_get_sender
+    ):
+        """Provider-invalid recipient domains are rejected before opening SMTP."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+
+            acc_id = self.create_account(cursor, uid)
+            mail_id = mailbox_obj.create(cursor, uid, {
+                'pem_from': 'test@example.com',
+                'pem_to': 'pepito@foobar',
+                'pem_subject': 'Test email',
+                'pem_body_text': 'Test body',
+                'pem_account_id': acc_id,
+                'folder': 'outbox',
+                'state': 'na',
+            })
+
+            mailbox_obj.send_this_mail(cursor, uid, [mail_id])
+
+            mail = mailbox_obj.read(
+                cursor, uid, mail_id, ['folder', 'history', 'state']
+            )
+            self.assertEqual(mail['folder'], 'error')
+            self.assertEqual(mail['state'], 'na')
+            self.assertIn(
+                'Header "To" contains an invalid email address: pepito@foobar',
+                mail['history']
+            )
+            self.assertFalse(mock_get_sender.called)
+
+    @patch('poweremail.poweremail_core.Email.send')
+    @patch('poweremail.poweremail_core.poweremail_core_accounts.get_sender')
+    def test_send_this_mail_subject_with_colon_sends(
+        self, mock_get_sender, mock_send
+    ):
+        """Colons in subject values are valid and must be encoded by qreu."""
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+
+            mock_send.return_value = True
+            acc_id = self.create_account(cursor, uid)
+            mail_id = mailbox_obj.create(cursor, uid, {
+                'pem_from': 'test@example.com',
+                'pem_to': 'recipient@example.com',
+                'pem_subject': 'Test email: with colon',
+                'pem_body_text': 'Test body',
+                'pem_account_id': acc_id,
+                'folder': 'outbox',
+                'state': 'na',
+            })
+
+            mailbox_obj.send_this_mail(cursor, uid, [mail_id])
+
+            mail = mailbox_obj.read(
+                cursor, uid, mail_id, ['folder', 'history', 'state']
+            )
+            self.assertEqual(mail['folder'], 'sent')
+            self.assertEqual(mail['state'], 'na')
+            self.assertIn('Email sent successfully', mail['history'])
+            self.assertTrue(mock_get_sender.called)
+            self.assertTrue(mock_send.called)
+
     def test_send_mail_invalid_extra_header_error(self):
         """Invalid custom headers return a clear error instead of sending."""
         with Transaction().start(self.database) as txn:


### PR DESCRIPTION
## Summary
- Validate email headers before opening the SMTP sender context.
- Reject invalid custom header names/values and malformed From/To/Cc/Bcc addresses with clear per-email errors.
- Reject provider-invalid recipient domains without a dot, e.g. `pepito@foobar`.
- Keep valid subject values with `:` accepted and covered by regression tests.
- Add regressions for invalid subject headers, invalid recipients, invalid custom headers, provider-invalid domains, and subject values with colons.

## Tests
- `python -m py_compile poweremail_core.py tests/test_poweremail_mailbox.py` with Python 2.7 and Python 3.11
- `destral -m poweremail -t test_poweremail_mailbox.TestPoweremailMailbox.test_send_this_mail_subject_with_colon_sends -t test_poweremail_mailbox.TestPoweremailMailbox.test_send_this_mail_recipient_domain_without_dot_error -t test_poweremail_mailbox.TestPoweremailMailbox.test_send_this_mail_invalid_recipient_header_error -t test_poweremail_mailbox.TestPoweremailMailbox.test_send_this_mail_invalid_subject_header_error -t test_poweremail_mailbox.TestPoweremailMailbox.test_send_mail_invalid_extra_header_error --quiet`

## Task
- TASK-91250

Fixes #221