### PR TITLE
Reorganized poweremail layout, logos and mail view.

### DIFF
--- a/migrations/5.0.26.12.0/post-0001_email_form_view_modifications.py
+++ b/migrations/5.0.26.12.0/post-0001_email_form_view_modifications.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from tools import config
+from oopgrade.oopgrade import load_data, MigrationHelper
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    # Update all views and menuitems across the modified XML files
+    load_data(cursor, 'poweremail', 'poweremail_core_view.xml', idref=None, mode='update')
+    load_data(cursor, 'poweremail', 'poweremail_mailbox_view.xml', idref=None, mode='update')
+
+    helper = MigrationHelper(cursor, 'poweremail')
+    helper.update_xml_records(
+        xml_path='wizard/wizard_emails_generats.xml',
+        update_record_ids=[
+            'menu_wizard_emails_generats'
+        ]
+    )
+
+def down(cursor, installed_version):
+    pass
+
+migrate = up

--- a/poweremail_core_view.xml
+++ b/poweremail_core_view.xml
@@ -254,17 +254,17 @@
 			<field name="context">{'company':'yes'}</field>
 		</record>
 
-		<menuitem name="Power Email" id="menu_poweremail_administration_server" />
+		<menuitem name="Power Email" id="menu_poweremail_administration_server" icon="mail"/>
 
-		<menuitem name="Configuration" id="menu_poweremail_configuration_server" parent="menu_poweremail_administration_server" />
+		<menuitem name="Configuration" id="menu_poweremail_configuration_server" parent="menu_poweremail_administration_server" icon="settings"/>
 
-		<menuitem name="All Accounts" id="menu_poweremail_core_accounts_all" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_all" groups="res_groups_pemanager" />
+		<menuitem name="All Accounts" id="menu_poweremail_core_accounts_all" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_all" groups="res_groups_pemanager" icon="mail-cog"/>
 
-		<menuitem name="Personal Accounts" id="menu_poweremail_core_accounts_Personal" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_per" groups="res_groups_pemanager" />
+		<menuitem name="Personal Accounts" id="menu_poweremail_core_accounts_Personal" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_per" groups="res_groups_pemanager" icon="users"/>
 
-		<menuitem name="Company Accounts" id="menu_poweremail_core_accounts_Personal_co" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_co" groups="res_groups_pemanager" />
+		<menuitem name="Company Accounts" id="menu_poweremail_core_accounts_Personal_co" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_co" groups="res_groups_pemanager" icon="buildings"/>
 
-		<menuitem name="My Accounts" id="menu_poweremail_core_accounts_Personal_my" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_my" />
+		<menuitem name="My Accounts" id="menu_poweremail_core_accounts_Personal_my" parent="menu_poweremail_configuration_server" action="action_poweremail_core_accounts_tree_my" icon="user"/>
 
 	</data>
 </openerp>

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -74,7 +74,7 @@
 							<field name="template_id" colspan="2" select="2" readonly="1" attrs="{'invisible': [('folder', '=', 'inbox')]}"/>
 							<field name="state" readonly="1" />
 						</page>
-						<page string="Logs" icon="contract">
+						<page string="Logs" icon="vocabulary">
 							<field name="history" nolabel="1" colspan="4" height="400"/>
 						</page>
                         <page string="Raw content" attrs="{'invisible':[('folder','!=','inbox')]}">

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -31,88 +31,75 @@
 				</tree>
 			</field>
 		</record>
-		<!-- Power Email Template PReview -->
+		<!-- Power Email Template Preview -->
 		<record model="ir.ui.view" id="poweremail_mailbox_form">
 			<field name="name">poweremail.mailbox.form</field>
 			<field name="model">poweremail.mailbox</field>
 			<field name="type">form</field>
 			<field name="arch" type="xml">
 				<form string="Power Email Inbox">
-					<group col="4" colspan="2">
+					<group col="8" colspan="4">
+						<field name="pem_subject" colspan="6" select="1"/>
+						<field name="date_mail" colspan="2" select="2" attrs="{'invisible': [('folder', '!=', 'inbox')]}" readonly="1"/>
+						<field name="pem_recd" colspan="2" select="1" attrs="{'invisible': [('folder', '=', 'inbox')]}" readonly="1"/>
 						<field name="pem_from" colspan="4" select="1"/>
+						<field name="pem_to" colspan="4" required="1" select="1"/>
 						<field name="pem_cc" colspan="4" select="1"/>
-						<field name="date_mail" colspan="4" select="2"/>
-						<field name="pem_recd" colspan="4" select="1"/>
-						<field name="template_id" colspan="4" select="2" readonly="1"/>
-					</group>
-					<group col="4" colspan="2">
-						<field name="pem_to" colspan="4" required="1" select="1" />
 						<field name="pem_bcc" colspan="4" select="2"/>
-						<field name="pem_subject" colspan="4" select="1"/>
-						<field name="priority" colspan="4" select="2"/>
 					</group>
 					<notebook colspan="4">
-						<page string="Standard Body">
-							<separator colspan="4" string="Standard Body" />
-							<notebook colspan="4">
-								<page string="Standard Body (Text)">
-									<field name="pem_body_text" nolabel="1" colspan="4" select="1"/>
-								</page>
-								<page string="Body (HTML-Web Client Only)">
-									<field name="pem_body_html" nolabel="1" colspan="4" widget="text_html"/>
-									<!--<label string="Note: HTML body can't be edited with GTK desktop client." colspan="4"/>
-								--></page>
-
-							</notebook>
+						<page string="Content">
+                            <card title="Preview" colspan="2" icon="eye">
+                                <field name="pem_body_text" nolabel="1" colspan="4" select="1" widget="html_preview"/>
+                            </card>
+                            <card title="Editor (HTML)" colspan="2" icon="code">
+                                <field name="pem_body_text" nolabel="1" colspan="4" widget="codeeditor" widget_props="{'lang': 'html'}"/>
+                                <!--<label string="Note: HTML body can't be edited with GTK desktop client." colspan="4"/>-->
+                            </card>
 						</page>
 
 
-						<page string="Attachments">
+						<page string="Attachments" icon="link">
 							<group col="4">
-								<separator colspan="4" string="Attachments" />
 								<field name="pem_attachments_ids" colspan="4" nolabel="1" height="400"/>
 							</group>
 						</page>
-						<page string="Advanced">
-							<group col="4">
-								<field name="pem_account_id" colspan="2" />
-								<field name="server_ref" colspan="2" />
-								<field name="mail_type" colspan="2" />
-								<field name="folder" colspan="2" select="2"/>
-								<separator string="History" colspan="4" />
-								<field name="history" nolabel="1" colspan="4" height="400"/>
-							</group>
+						<page string="Advanced" icon="settings">
+							<field name="pem_account_id" colspan="2" />
+							<field name="priority" colspan="2" select="2"/>
 						</page>
-                        <page string="Raw content">
+						<page string="Information" icon="info-circle">
+							<field name="server_ref" colspan="2" attrs="{'invisible': [('folder', '=', 'inbox')]}"/>
+							<field name="mail_type" colspan="2" />
+							<field name="template_id" colspan="2" select="2" readonly="1" attrs="{'invisible': [('folder', '=', 'inbox')]}"/>
+							<field name="state" readonly="1" />
+						</page>
+						<page string="Logs" icon="contract">
+							<field name="history" nolabel="1" colspan="4" height="400"/>
+						</page>
+                        <page string="Raw content" attrs="{'invisible':[('folder','!=','inbox')]}">
                             <field name="pem_mail_orig" nolabel="1" readonly="1" height="400" colspan="4"/>
                         </page>
 					</notebook>
-					<separator colspan="4" string="" />
-					<group col="4" colspan="4">
-						<field name="state" colspan="2" readonly="1" />
-						<button name="complete_mail" type="object" string="Download Full Mail" colspan="2" states="read,unread" />
-						<button name="send_this_mail" type="object" string="Send Mail" />
+					<group col="8" colspan="4">
+						<field name="folder" colspan="2" select="2"/>
+						<button name="complete_mail"
+								type="object"
+								string="Download Full Mail"
+								colspan="2" states="read,unread"
+								primary="1"
+								icon="download"
+								attrs="{'invisible': [('folder', '!=', 'inbox')]}"/>
+						<button name="send_this_mail"
+								type="object"
+								string="Send Mail"
+								colspan="2"
+								primary="1"
+								icon="send"
+								attrs="{'invisible': [('folder', '=', 'inbox')]}"/>
 					</group>
 				</form>
 			</field>
-		</record>
-
-		<record model="ir.ui.view" id="view_poweremail_mailbox_2_form">
-		    <field name="name">poweremail_mailbox.form_2</field>
-		    <field name="model">poweremail.mailbox</field>
-		    <field name="type">form</field>
-			<field name="version">2</field>
-			<field name="inherit_id" ref="poweremail_mailbox_form" />
-		    <field name="arch" type="xml">
-		       <data>
-				   <xpath expr="//field[@name='pem_body_text']" position="attributes">
-					   <attribute name="widget">html_preview</attribute>
-				   </xpath>
-				   <xpath expr="//field[@name='pem_body_html']" position="attributes">
-					   <attribute name="widget">html_preview</attribute>
-				   </xpath>
-			   </data>
-		    </field>
 		</record>
 
 		<!--8888888888888888888888888888888888 TREE VIEWS 8888888888888888888888888888888888888888-->
@@ -442,29 +429,37 @@
 			<field name="context">{'company':True}</field>
 		</record>
 		<!--8888888888888888888888888888888888 MENUS 8888888888888888888888888888888888888888-->
-		<menuitem name="MailBox" id="menu_poweremail_mailbox_all_main2" parent="menu_poweremail_administration_server" />
-		<menuitem name="Personal" id="menu_poweremail_personal" parent="menu_poweremail_mailbox_all_main2" />
-		<menuitem name="All emails" id="menu_poweremail_all_emails" parent="menu_poweremail_personal" action="action_poweremail_all_emails_tree" />
-		<menuitem name="Inbox" id="menu_poweremail_inbox" parent="menu_poweremail_personal" action="action_poweremail_inbox_tree" />
-		<menuitem name="Inbox Conversations" id="menu_poweremail_inbox_conversation" parent="menu_poweremail_personal" action="action_poweremail_conversation_tree" />
-		<menuitem name="Drafts" id="menu_poweremail_drafts" parent="menu_poweremail_personal" action="action_poweremail_drafts_tree" />
-		<menuitem name="Outbox" id="menu_poweremail_outbox" parent="menu_poweremail_personal" action="action_poweremail_outbox_tree" />
-		<menuitem name="Follow-up" id="menu_poweremail_follow" parent="menu_poweremail_personal" action="action_poweremail_follow_tree" />
-		<menuitem name="Sent" id="menu_poweremail_sent" parent="menu_poweremail_personal" action="action_poweremail_sent_tree" />
-		<menuitem name="Sending" id="menu_action_poweremail_sending_tree" parent="poweremail.menu_poweremail_personal" action="action_poweremail_sending_tree" />
-		<menuitem name="Trash" id="menu_poweremail_trash" parent="menu_poweremail_personal" action="action_poweremail_trash_tree" />
-        <menuitem name="Error" id="menu_poweremail_error_personal" parent="menu_poweremail_personal" action="action_poweremail_error_tree_personal" />
+		<menuitem name="MailBox" id="menu_poweremail_mailbox_all_main2" parent="menu_poweremail_administration_server" icon="mailbox" />
 
-		<menuitem name="Company" id="menu_poweremail_company" parent="menu_poweremail_mailbox_all_main2" />
-		<menuitem name="All emails" id="menu_poweremail_all_emails_company" parent="menu_poweremail_company" action="action_poweremail_all_emails_tree_company" />.
-		<menuitem name="Inbox" id="menu_poweremail_inbox_company" parent="menu_poweremail_company" action="action_poweremail_inbox_tree_company" />
-		<menuitem name="Drafts" id="menu_poweremail_drafts_company" parent="menu_poweremail_company" action="action_poweremail_drafts_tree_company" />
-		<menuitem name="Outbox" id="menu_poweremail_outbox_company" parent="menu_poweremail_company" action="action_poweremail_outbox_tree_company" />
-		<menuitem name="Follow-up" id="menu_poweremail_follow_company" parent="menu_poweremail_company" action="action_poweremail_follow_tree_company" />
-		<menuitem name="Sent" id="menu_poweremail_sent_company" parent="menu_poweremail_company" action="action_poweremail_sent_tree_company" />
-		<menuitem name="Sending" id="menu_action_poweremail_sending_tree_company" parent="poweremail.menu_poweremail_company" action="action_poweremail_sending_tree_company" />
-		<menuitem name="Trash" id="menu_poweremail_trash_company" parent="menu_poweremail_company" action="action_poweremail_trash_tree_company" />
-		<menuitem name="Error" id="menu_poweremail_error_company" parent="menu_poweremail_company" action="action_poweremail_error_tree_company" />
+		<!-- PERSONAL -->
+		<menuitem name="Personal" id="menu_poweremail_personal" parent="menu_poweremail_mailbox_all_main2" icon="user" />
+		<menuitem name="All emails" id="menu_poweremail_all_emails" parent="menu_poweremail_personal" action="action_poweremail_all_emails_tree" icon="mail" />
+		<menuitem name="Sent" id="menu_poweremail_sent" parent="menu_poweremail_personal" action="action_poweremail_sent_tree" icon="send" />
+		<menuitem name="Error" id="menu_poweremail_error_personal" parent="menu_poweremail_personal" action="action_poweremail_error_tree_personal" icon="alert-circle" />
+		<!-- OTHERS -->
+		<menuitem name="Others" id="menu_poweremail_personal_others" parent="menu_poweremail_personal" icon="folder" />
+		<menuitem name="Inbox" id="menu_poweremail_inbox" parent="menu_poweremail_personal_others" action="action_poweremail_inbox_tree" icon="mail-down" />
+		<menuitem name="Outbox" id="menu_poweremail_outbox" parent="menu_poweremail_personal_others" action="action_poweremail_outbox_tree" icon="mail-up" />
+		<menuitem name="Inbox Conversations" id="menu_poweremail_inbox_conversation" parent="menu_poweremail_personal_others" action="action_poweremail_conversation_tree" icon="messages" />
+		<menuitem name="Drafts" id="menu_poweremail_drafts" parent="menu_poweremail_personal_others" action="action_poweremail_drafts_tree" icon="edit" />
+		<menuitem name="Follow-up" id="menu_poweremail_follow" parent="menu_poweremail_personal_others" action="action_poweremail_follow_tree" icon="clock" />
+		<menuitem name="Sending" id="menu_action_poweremail_sending_tree" parent="menu_poweremail_personal_others" action="action_poweremail_sending_tree" icon="loader" />
+		<menuitem name="Trash" id="menu_poweremail_trash" parent="menu_poweremail_personal_others" action="action_poweremail_trash_tree" icon="trash" />
+
+		<!-- COMPANY -->
+		<menuitem name="Company" id="menu_poweremail_company" parent="menu_poweremail_mailbox_all_main2" icon="building" />
+		<menuitem name="All emails" id="menu_poweremail_all_emails_company" parent="menu_poweremail_company" action="action_poweremail_all_emails_tree_company" icon="mail" />
+		<menuitem name="Sent" id="menu_poweremail_sent_company" parent="menu_poweremail_company" action="action_poweremail_sent_tree_company" icon="send" />
+		<menuitem name="Error" id="menu_poweremail_error_company" parent="menu_poweremail_company" action="action_poweremail_error_tree_company" icon="alert-circle" />
+		<!-- OTHERS -->
+		<menuitem name="Others" id="menu_poweremail_company_others" parent="menu_poweremail_company" icon="folder" />
+		<menuitem name="Inbox" id="menu_poweremail_inbox_company" parent="menu_poweremail_company_others" action="action_poweremail_inbox_tree_company" icon="mail-down" />
+		<menuitem name="Outbox" id="menu_poweremail_outbox_company" parent="menu_poweremail_company_others" action="action_poweremail_outbox_tree_company" icon="mail-up" />
+		<menuitem name="Drafts" id="menu_poweremail_drafts_company" parent="menu_poweremail_company_others" action="action_poweremail_drafts_tree_company" icon="edit" />
+		<menuitem name="Follow-up" id="menu_poweremail_follow_company" parent="menu_poweremail_company_others" action="action_poweremail_follow_tree_company" icon="clock" />
+		<menuitem name="Sending" id="menu_action_poweremail_sending_tree_company" parent="menu_poweremail_company_others" action="action_poweremail_sending_tree_company" icon="loader" />
+		<menuitem name="Trash" id="menu_poweremail_trash_company" parent="menu_poweremail_company_others" action="action_poweremail_trash_tree_company" icon="trash" />
+
 		<!-- LIST THE MAILS GENERATED WITH THE SAME TEMPLATE -->
 		<record model="ir.actions.act_window" id="action_template_emails">
 			<field name="name">Template emails</field>

--- a/poweremail_mailbox_view.xml
+++ b/poweremail_mailbox_view.xml
@@ -102,6 +102,21 @@
 			</field>
 		</record>
 
+		<record model="ir.ui.view" id="view_poweremail_mailbox_2_form">
+		    <field name="name">poweremail_mailbox.form_2</field>
+		    <field name="model">poweremail.mailbox</field>
+		    <field name="type">form</field>
+			<field name="version">2</field>
+			<field name="inherit_id" ref="poweremail_mailbox_form" />
+		    <field name="arch" type="xml">
+		       <data>
+				   <xpath expr="//field[@name='pem_body_text']" position="attributes">
+					   <attribute name="widget">html_preview</attribute>
+				   </xpath>
+			   </data>
+		    </field>
+		</record>
+
 		<!--8888888888888888888888888888888888 TREE VIEWS 8888888888888888888888888888888888888888-->
 		<!--ALL EMAILS-->
 		<record model="ir.ui.view" id="poweremail_all_emails_tree">

--- a/wizard/wizard_emails_generats.xml
+++ b/wizard/wizard_emails_generats.xml
@@ -25,6 +25,7 @@
         <menuitem id="menu_wizard_emails_generats"
                   action="action_wizard_emails_generats_model"
                   parent="menu_poweremail_administration_server"
+                  icon="bolt"
         />
 
     </data>


### PR DESCRIPTION
# New behavior
- Added logo to the menu items for proper visualization and reorganization of the view form of a mail.
- <img width="1856" height="841" alt="image" src="https://github.com/user-attachments/assets/346cc5bc-00ec-4aef-b202-72d5f14af14d" />


# Old behavior
The menu items had the same icons and the information of a mail in the view was no well arranged.

# Checklist

- [ ] Tests (if not implemented, explain why)
- Since this PR only modifies the views and doesn't modify any logical part of the module, test is not required.
- [ ] Document new behaviour if necessary (RFC forum)

# Related

- Dependency: 
  - https://github.com/gisce/poweremail/pull/203
  - https://github.com/gisce/poweremail/pull/213

- [ ] Related PR: 
- [x] TASK-91685
