### PR TITLE
Corregir com obtenir el valor del camp "Para" en l'assistent d'enviar factures

### DIFF
--- a/poweremail_send_wizard.py
+++ b/poweremail_send_wizard.py
@@ -30,7 +30,7 @@ import time
 from tools.translate import _
 import tools
 from .poweremail_template import get_value
-from .poweremail_core import filter_send_emails, _priority_selection
+from .poweremail_core import _priority_selection
 from premailer import transform
 
 
@@ -177,9 +177,9 @@ class poweremail_send_wizard(osv.osv_memory):
         'state': lambda self,cr,uid,ctx: len(ctx['src_rec_ids']) > 1 and 'send_type' or 'single',
         'rel_model': lambda self,cr,uid,ctx: self.pool.get('ir.model').search(cr,uid,[('model','=',ctx['src_model'])],context=ctx)[0],
         'rel_model_ref': lambda self,cr,uid,ctx: ctx['active_id'],
-        'to': lambda self,cr,uid,ctx: filter_send_emails(self._get_template_value(cr, uid, 'def_to', ctx)),
-        'cc': lambda self,cr,uid,ctx: filter_send_emails(self._get_template_value(cr, uid, 'def_cc', ctx)),
-        'bcc': lambda self,cr,uid,ctx: filter_send_emails(self._get_template_value(cr, uid, 'def_bcc', ctx)),
+        'to': lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_to', ctx),
+        'cc': lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_cc', ctx),
+        'bcc': lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_bcc', ctx),
         'subject':lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_subject', ctx),
         'body_text':lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_body_text', ctx),
         'body_html':lambda self,cr,uid,ctx: self._get_template_value(cr, uid, 'def_body_html', ctx),

--- a/tests/test_poweremail_templates.py
+++ b/tests/test_poweremail_templates.py
@@ -177,6 +177,53 @@ class TestPoweremailTemplates(testing.OOTestCaseWithCursor):
         wiz = send_obj.browse(cursor, uid, wiz_id)
         self.assertEqual(wiz.priority, '2')
 
+    def test_send_wizard_renders_recipient_for_each_selected_record(self):
+        partner_obj = self.openerp.pool.get('res.partner')
+        address_obj = self.openerp.pool.get('res.partner.address')
+        send_obj = self.openerp.pool.get('poweremail.send.wizard')
+        mailbox_obj = self.openerp.pool.get('poweremail.mailbox')
+        cursor = self.cursor
+        uid = self.uid
+
+        partner_ids = []
+        expected_recipients = []
+        for index in range(2):
+            email = 'customer{}@example.com'.format(index)
+            partner_id = partner_obj.create(cursor, uid, {
+                'name': 'Customer {}'.format(index),
+            })
+            address_obj.create(cursor, uid, {
+                'partner_id': partner_id,
+                'name': 'Notification address {}'.format(index),
+                'email': email,
+            })
+            partner_ids.append(partner_id)
+            expected_recipients.append(email)
+
+        template_id = self.create_template({
+            'def_to': '${object.address[0].email}',
+            'def_subject': 'Invoice',
+        })
+        context = {
+            'active_id': partner_ids[0],
+            'active_ids': partner_ids,
+            'src_rec_ids': partner_ids,
+            'src_model': 'res.partner',
+            'template_id': template_id,
+        }
+        wizard_id = send_obj.create(cursor, uid, {}, context=context)
+
+        mail_ids = send_obj.save_to_mailbox(
+            cursor, uid, [wizard_id], context=context
+        )
+        recipients = mailbox_obj.read(
+            cursor, uid, mail_ids, ['pem_to'], context=context
+        )
+
+        self.assertEqual(
+            [mail['pem_to'] for mail in recipients], expected_recipients
+        )
+
     def test_inliner_from_template_send_wizard(self):
         imd_obj = self.openerp.pool.get('ir.model.data')
         tmpl_obj = self.openerp.pool.get('poweremail.templates')


### PR DESCRIPTION
# New behavior
Obtenim correctament el valor que indica la plantilla de correu en cas de que l'assistent s'utilitzi amb més d'una factura.

# Old behavior
Quan utilitzavem l'assistent amb més d'una factura, aquesta intentava calcular el valor que havia d'anar al camp "Para" i ho feia incorrectament, provocant que el camp quedes en blanc i no es pogues enviar el correu

# Checklist
- [x] Tests

# Related
- [x] TASK-92873
