### PR TITLE
Show related PowerEmail templates directly in the Report XML view

### DIFF
--- a/i18n/ca_ES.po
+++ b/i18n/ca_ES.po
@@ -1,5 +1,3 @@
-# Translation of OpenERP Server.
-# This file contains the translation of the following modules:
 # 
 # Translators:
 #   <>, 2023, 2024, 2025, 2026.
@@ -8,218 +6,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2026-03-20 11:21\n"
-"PO-Revision-Date: 2026-03-20 10:24+0000\n"
+"PO-Revision-Date: 2026-08-24 12:59+0000\n"
 "Last-Translator: destanyol <>\n"
 "Language-Team: Catalan (Spain) <erp@dev.gisce.net>\n"
-"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
 "Language: ca_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: poweremail
-#: help:poweremail.templates,send_immediately:0
+#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
 msgid ""
-"Emails created from this template will be sent immediately without going "
-"throug outbox folder."
-msgstr "Els correus electrònics creats a partir d’aquesta plantilla s’enviaran immediatament sense passar per la carpeta de sortida."
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
-msgid "Shows a list of IMAP folders"
-msgstr "Mostra la llista de les carpetes IMAP"
-
-#. module: poweremail
-#: field:poweremail.templates,def_bcc:0
-msgid "Default BCC"
-msgstr "BCC per defecte"
-
-#. module: poweremail
-#: help:poweremail.templates,model_object_field:0
-msgid ""
-"Select the field from the model you want to use.\n"
-"If it is a relationship field you will be able to choose the nested values in the box below.\n"
-"(Note: If there are no values make sure you have selected the correct model)."
-msgstr "Seleccioneu el camp del model que voleu utilitzar.\nSi és un camp de relació podreu triar els valors relacionats en l'opció inferior.\n(Nota: Si no hi han valors assegureu-vos de seleccionar el model correcte)."
-
-#. module: poweremail
-#: constraint:ir.actions.act_window:0
-msgid "Invalid model name in the action definition."
-msgstr "Nom del model invàlid en la definició de l'acció."
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid " "
-msgstr " "
-
-#. module: poweremail
-#: field:poweremail.templates,attached_wkf:0
-msgid "Workflow"
-msgstr "Flux de treball"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,single_email:0
-#: field:poweremail.templates,single_email:0
-msgid "Single email"
-msgstr "Només un correu electrònic"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:904
-#, python-format
-msgid "Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr "Correu %s desat correctament com ID: %s pel compte: %s."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
-msgid "Personal Account"
-msgstr "Compte personal"
-
-#. module: poweremail
-#: field:poweremail.mailbox,server_ref:0
-msgid "Server Reference of mail"
-msgstr "Referència del servidor de correu"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
-msgid "My Accounts"
-msgstr "Els meus comptes"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Incoming"
-msgstr "Entrada"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#, python-format
-msgid ""
-"Sending of Mail %s failed. Probable Reason: Could not login to server\n"
-"Error: %s"
-msgstr "L'enviament del correu %s ha fallat. Motiu probable: No s'ha autenticat amb el servidor.\nError: %s"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Un-Read"
-msgstr "Sense llegir"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:576
-#, python-format
-msgid "The template name must be unique!"
-msgstr "El nom de la plantilla ha de ser únic!"
-
-#. module: poweremail
-#: field:poweremail.mailbox,conversation_id:0
-msgid "Conversation"
-msgstr "Conversació"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:336
-#: code:addons/poweremail/poweremail_send_wizard.py:368
-#, python-format
-msgid "No Description"
-msgstr "No hi ha descripció"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Note: HTML body can't be edited with GTK desktop client."
-msgstr "Nota: El cos HTML no es pot editar amb el client de escriptori GTK."
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Wizard Complete"
-msgstr "Assistent complert"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Not Applicable"
-msgstr "No aplicable"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
-msgid "Mailbox: Drafts"
-msgstr "Safata: Esborranys"
-
-#. module: poweremail
-#: model:ir.module.module,shortdesc:poweremail.module_meta_information
-msgid "Powerful Email capabilities for Open ERP"
-msgstr "Funcionalitats de correu potents per a OpenERP"
-
-#. module: poweremail
-#: field:poweremail.templates,inline:0
-msgid "Inline HTML"
-msgstr "Inline HTML"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:56
-#, python-format
-msgid "Mako templates not installed"
-msgstr "Les plantilles Mako no estan instal·lades"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,requested:0
-msgid "No of requested Mails"
-msgstr "Número de missatges sol·licitats"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "POP3"
-msgstr "POP3"
-
-#. module: poweremail
-#: help:poweremail.templates,model_data_name:0
-msgid "Model Data Name."
-msgstr "Nom de les dades del model."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Stats"
-msgstr "Estadístiques"
-
-#. module: poweremail
-#: help:poweremail.templates,null_value:0
-msgid "This Value is used if the field is empty."
-msgstr "Aquest valor s'utilitza si el camp es troba buit."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Send/Receive"
-msgstr "Envia/Rebre"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
-msgid "MailBox"
-msgstr "Bústia"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpssl:0
-msgid "Start a SMTP connection through SSL (Usually port 465)"
-msgstr "Establir una connexió SMTP utilitzant SSL (normalment port 465)"
-
-#. module: poweremail
-#: field:poweremail.templates,table_sub_object:0
-msgid "Table-model"
-msgstr "Model-Taula"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "self - objects pointer"
-msgstr "self - punters a objectes"
-
-#. module: poweremail
-#: view:ir.actions.server:0
-msgid ""
-"All values for the mail can be configured in the template editor itself."
-msgstr "Tots els valors del correu es poden configurar a l'editor de plantilles."
-
-#. module: poweremail
-#: help:poweremail.templates,stats_interval:0
-msgid ""
-"Number of days used to calculate the send count backwards from today. If "
-"empty or zero, all sent emails are taken into account."
-msgstr "Nombre de dies utilitzats per calcular cap enrere des d'avui el nombre de correus enviats. Si està buit o és zero, es tenen en compte tots els correus enviats."
+"\n"
+"\n"
+"<!doctype html>\n"
+"<html>\n"
+"<head></head>\n"
+"<body>\n"
+"Benvolgut/da ${object.login},\n"
+"\n"
+"Això és un email generic de prova per les poweremail_camapign.\n"
+"\n"
+"\n"
+"Atentament,\n"
+"\n"
+"un mort de gana.\n"
+"</body>\n"
+"</html>\n"
+"\n"
+"\t\t\t"
+msgstr "\n\n<!doctype html>\n<html>\n<head></head>\n<body>\nBenvolgut/da ${object.login},\n\nAixò és un email generic de prova per les poweremail_camapign.\n\n\nAtentament,\n\nun mort de gana.\n</body>\n</html>\n\n\t\t\t"
 
 #. module: poweremail
 #: model:ir.module.module,description:poweremail.module_meta_information
@@ -245,94 +60,129 @@ msgid ""
 msgstr "\n Power Email - Amplia OpenERP amb característiques de correu electrònic.\n ============================================================================\n Característiques\n ============================================================================\n 1. Varis comptes de correu electrònic\n 2. Comptes de companyia i personal\n 3. Seguretat (en desenvolupament)\n 4. Carpetes de correu electrònic (safata entrada, sortida, esborranys, ...)\n 5. Enviar correu via SMTP (SMTP SSL també està suportat)\n 6. Recepció de correus (IMAP & POP3) amb SSL i carpetes IMAP.\n 7. Dissenyador de plantilles senzill amb sistema d'actualització automàtic. No es requereix configuració extra.\n 8. Correus electrònics automàtics segons estats d'un flux de treball\n ============================================================================\n NOTA: És una versió Beta. Per errors:\n http://bugs.launchpad.net/poweremail/+filebug (o) https://bugs.launchpad.net/poweremail/+filebug\n ============================================================================\n Propostes i Feedback: sharoon.thomas@openlabs.co.in\n ============================================================================\n    "
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
-msgid "Mailbox: Outbox"
-msgstr "Safata: Sortida"
+#: view:poweremail.send.wizard:0
+msgid " "
+msgstr " "
 
 #. module: poweremail
-#: view:poweremail.core_selfolder:0 view:poweremail.send.wizard:0
-msgid "Cancel"
-msgstr "Cancel·la"
+#: field:poweremail.mailbox,pem_bcc:0
+msgid " BCC"
+msgstr " BCC"
 
 #. module: poweremail
-#: field:poweremail.templates,last_send_date:0
-msgid "Last Sent Date"
-msgstr "Data de l'últim enviament"
+#: field:poweremail.mailbox,pem_cc:0
+msgid " CC"
+msgstr " CC"
 
 #. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
-msgid "Poweremail scheduler"
-msgstr "Planificador de poweremail"
+#: field:poweremail.mailbox,pem_subject:0
+msgid " Subject"
+msgstr "Assumpte"
 
 #. module: poweremail
-#: field:poweremail.templates,table_required_fields:0
-msgid "Required Fields"
-msgstr "Camps requerits"
+#: model:poweremail.templates,file_name:poweremail.default_template_poweremail_2
+msgid "${object.number}"
+msgstr "${object.number}"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:925
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
-msgid "No Subject"
-msgstr "No hi ha assumpte"
+msgid "%s (Email Attachment)"
+msgstr "%s (Email Attachment)"
 
 #. module: poweremail
-#: field:poweremail.templates,sub_object:0
-msgid "Sub-model"
-msgstr "Sub-model"
-
-#. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:154
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "No model reference defined"
-msgstr "Model de referència no definit"
+msgid "%s Mail Form"
+msgstr "%s formulari de correu"
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "IMAP"
-msgstr "IMAP"
-
-#. module: poweremail
-#: field:poweremail.mailbox,date_mail:0
-msgid "Rec/Sent Date"
-msgstr "Data recepció/enviament"
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_write:0
-msgid "Send on Update"
-msgstr "Envia a l'actualitzar"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Server Information"
-msgstr "Informació del servidor"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
-msgstr "Nº de correus generats"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isuser:0
-#: field:poweremail.core_accounts,smtpuname:0
-msgid "User Name"
-msgstr "Nom d'usuari"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:348
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "IMAP Server Login Error: {}"
-msgstr "Error de login al servidor IMAP: {}"
+msgid "%s account not found"
+msgstr "%s compte no trobat"
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Suspended"
-msgstr "Suspès"
+#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail
+msgid ""
+"<!doctype html>\n"
+"<html>\n"
+"<head></head>\n"
+"<body>\n"
+"This is a demo email\n"
+"</body>\n"
+"</html>"
+msgstr "<!doctype html>\n<html>\n<head></head>\n<body>\nThis is a demo email\n</body>\n</html>"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
-msgid "Email Mailbox Conversation"
-msgstr "Conversa"
+#: field:poweremail.core_accounts,state:0
+msgid "Account Status"
+msgstr "Estat del compte"
+
+#. module: poweremail
+#: field:poweremail.templates,use_filter:0
+msgid "Active Filter"
+msgstr "Filtre actiu"
+
+#. module: poweremail
+#: field:poweremail.templates,attached_activity:0
+msgid "Activity"
+msgstr "Activitat"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid ""
+"Add here all attachments of the current document you want to include in the "
+"e-mail."
+msgstr "Afegiu aquí tots els fitxers adjunts del document actual que vulgueu incloure al correu."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0 view:poweremail.templates:0
+msgid "Advanced"
+msgstr "Avançat"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid ""
+"After clicking send all mails, mails will be sent to outbox and cleared in "
+"next Send/Recieve"
+msgstr "Després de fer clic a \"Envia tots els correus\", els correus s’enviaran a la safata de sortida i s’eliminaran en el proper \"Envia/Rep\"."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_all
+msgid "All Accounts"
+msgstr "Tots els comptes"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr "Tots els correus"
+
+#. module: poweremail
+#: view:ir.actions.server:0
+msgid ""
+"All values for the mail can be configured in the template editor itself."
+msgstr "Tots els valors del correu es poden configurar a l'editor de plantilles."
+
+#. module: poweremail
+#: field:poweremail.core_accounts,allowed_groups:0
+#: field:poweremail.templates,allowed_groups:0 view:poweremail.templates:0
+msgid "Allowed User Groups"
+msgstr "Grups d'usuaris permesos"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "An error occurred while rendering template id {}:  {}"
+msgstr "Un error ha passat mentre es renderitzava la plantilla amb id {}:  {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "An error occurred: %s"
+msgstr "S'ha produït un error: %s"
 
 #. module: poweremail
 #: help:poweremail.mailbox,server_ref:0
@@ -340,87 +190,182 @@ msgid "Applicable for inward items only."
 msgstr "Aplicable només pels elements d'entrada."
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1084
-#, python-format
-msgid "IMAP Folder Statistics for Account: %s: %s"
-msgstr "Estadístiques de carpeta IMAP pel compte: %s: %s"
+#: view:poweremail.core_accounts:0
+msgid "Approve Account"
+msgstr "Aprova el compte"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
-msgid "Emails sent"
-msgstr "Correus enviats"
+#: selection:poweremail.core_accounts,state:0
+msgid "Approved"
+msgstr "Aprovat"
 
 #. module: poweremail
-#: constraint:poweremail.core_accounts:0
-msgid "Error: You are not allowed to have more than 1 account."
-msgstr "Error: No té permès tenir més d'1 compte."
+#: field:poweremail.send.wizard,signature:0
+msgid "Attach my signature to mail"
+msgstr "Afegeix la meva signatura al correu"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
-msgid "Inbox Conversations"
-msgstr "Converses"
-
-#. module: poweremail
-#: field:poweremail.mailbox,mail_type:0
-msgid "Mail Contents"
-msgstr "Contingut del correu electrònic"
+#: field:poweremail.templates,attach_record_items:0
+msgid "Attach record items"
+msgstr "Adjuntar elements"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "More information"
-msgstr "Més informació"
+msgid "Attachment settings"
+msgstr "Configuració de l'adjunt"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:329
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "%s (Email Attachment)"
-msgstr "%s (adjunt correu electrònic)"
+msgid "Attachment to mail for %s relation failed Account: %s."
+msgstr "Adjunt de correu per la relació %s ha fallat. Compte: %s."
 
 #. module: poweremail
-#: field:poweremail.mailbox,state:0 field:poweremail.send.wizard,state:0
-msgid "Status"
-msgstr "Estat"
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Attachment to mail for %s relation success! Account: %s."
+msgstr "Adjunt de correu per la relació %s correcte! Compte: %s."
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Outgoing"
-msgstr "Sortida"
+#: field:poweremail.mailbox,pem_attachments_ids:0
+#: field:poweremail.send.wizard,attachment_ids:0
+#: field:poweremail.templates,ir_attachment_ids:0
+#: field:poweremail.templates,tmpl_attachment_ids:0 view:poweremail.mailbox:0
+#: view:poweremail.send.wizard:0 view:poweremail.template.attachment:0
+msgid "Attachments"
+msgstr "Adjunts"
 
 #. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Intermixed content"
-msgstr "Contingut variat"
+#: field:poweremail.templates,auto_email:0
+msgid "Auto Email"
+msgstr "Correu electrònic automàtic"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Automatisms settings"
+msgstr "Configuració de l'automatització"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Available global variables:"
+msgstr "Available global variables:"
+
+#. module: poweremail
+#: field:poweremail.preview,bcc:0 field:poweremail.send.wizard,bcc:0
+msgid "BCC"
+msgstr "BCC"
+
+#. module: poweremail
+#: field:poweremail.preview,body_html:0 field:poweremail.preview,body_text:0
+#: field:poweremail.send.wizard,body_html:0
+#: field:poweremail.send.wizard,body_text:0
+msgid "Body"
+msgstr "Cos del missatge"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0 view:poweremail.templates:0
+msgid "Body (HTML)"
+msgstr "Cos del missatge (HTML)"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Body (Plain Text)"
+msgstr "Cos (text sense format)"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Body (Text)"
+msgstr "Cos del missatge (Text)"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_html:0
+#: field:poweremail.templates,def_body_html:0
+msgid "Body (Text-Web Client Only)"
+msgstr "Cos del missatge (Text - Només client web)"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body HTML"
+msgstr "Cos HTML"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body preview"
+msgstr "Vista prèvia del cos"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Both HTML & Text"
+msgstr "A la vegada HTML i Text"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
+msgstr "Buscar Correus Relacionats"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
+msgstr "Buscar correus relacionats"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
+msgstr "Buscar correus"
+
+#. module: poweremail
+#: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
+msgid "CC"
+msgstr "CC"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0 view:poweremail.send.wizard:0
+msgid "Cancel"
+msgstr "Cancel·la"
 
 #. module: poweremail
 #: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
 #: view:wizard.send.email:0
-msgid "Finalitzar"
-msgstr "Finalitzar"
+msgid "Cancel·lar"
+msgstr "Cancel·lar"
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
-msgid "wizard.emails.generats.model"
-msgstr "wizard.emails.generats.model"
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Cannot send mails of accounts {} when the addresses list is empty"
+msgstr "No es poden envair els correus dels comptes {} quan la llista d'adreces és buida"
 
 #. module: poweremail
-#: help:poweremail.templates,sub_object:0
-msgid ""
-"When a relation field is used this field will show you the type of field you"
-" have selected."
-msgstr "Quan s'utilitza un camp de relació, aquest camp mostrarà el tipus de camp que heu seleccionat."
+#: model:ir.actions.act_window,name:poweremail.action_wizard_change_folder_email_form
+#: view:wizard.change.folder.email:0
+msgid "Canviar emails de carpeta"
+msgstr "Canviar emails de safata"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
+#: view:wizard.change.state.email:0
+msgid "Canviar estat dels emails"
+msgstr "Canviar estat dels emails"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Incoming Connection"
+msgstr "Comprova la connexió d'entrada"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Outgoing Connection"
+msgstr "Comprova la connexió de sortida"
 
 #. module: poweremail
 #: view:poweremail.send.wizard:0
-msgid "Save in Drafts"
-msgstr "Desa a esborranys"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
 msgid ""
-"Add here all attachments of the current document you want to include in the "
-"e-mail."
-msgstr "Afegiu aquí tots els adjunts del document actual que voleu incloure en el correu electrònic."
+"Check it if you want to send a single email for several records (the "
+"optional attachment will be generated as a single file for all these r "
+"ecords). If you don't check it, an email with its optional attachment will "
+"be send for each record."
+msgstr "Marqueu aquesta opció si voleu enviar un únic correu per a diversos registres (el fitxer adjunt opcional es generarà com un únic fitxer per a tots aquests registres). Si no la marqueu, s’enviarà un correu amb el seu fitxer adjunt opcional per a cada registre."
 
 #. module: poweremail
 #: help:poweremail.send.wizard,single_email:0
@@ -433,30 +378,50 @@ msgid ""
 msgstr "Seleccioneu-lo si voleu enviar un únic correu electrònic per als diversos registres (l'adjunt opcional es genera com un únic arxiu per a tots aquests registres). Si no el seleccioneu, s'envia un correu electrònic amb el seu adjunt opcional per a cada registre."
 
 #. module: poweremail
-#: field:poweremail.template.attachment,search_params:0
-msgid "Search params"
-msgstr "Paràmetres de recerca"
+#: view:poweremail.send.wizard:0
+msgid "Close"
+msgstr "Tanca"
 
 #. module: poweremail
-#: field:poweremail.preview,save_to_drafts_prev:0
-#: field:poweremail.templates,save_to_drafts:0
-msgid "Save to Drafts"
-msgstr "Desa a esborranys"
+#: field:poweremail.templates,model_data_name:0
+msgid "Code"
+msgstr "Codi"
 
 #. module: poweremail
-#: field:poweremail.templates,copyvalue:0
-msgid "Expression"
-msgstr "Expressió"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
+msgid "Company"
+msgstr "Companyia"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
+msgid "Company Accounts"
+msgstr "Comptes de la companyia"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,company:0
+msgid "Company Mail A/c"
+msgstr "Compte correu de la companyia"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,full_success:0
+msgid "Complete Success"
+msgstr "El procés s'ha realitzat correctament"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
+msgid "Configuration"
+msgstr "Configuració"
 
 #. module: poweremail
 #: view:poweremail.mailbox:0
-msgid "Raw content"
-msgstr "Contingut brut (raw)"
+msgid "Content"
+msgstr "Contingut"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_bcc:0
-msgid " BCC"
-msgstr " BCC"
+#: field:poweremail.mailbox,conversation_id:0
+msgid "Conversation"
+msgstr "Conversació"
 
 #. module: poweremail
 #: model:ir.model,name:poweremail.model_poweremail_conversation
@@ -464,87 +429,77 @@ msgid "Conversations are groups of related emails"
 msgstr "Conversacions són grups de correus relacionats"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,allowed_groups:0
+#: help:poweremail.templates,copyvalue:0
 msgid ""
-"Only users from these groups will be allowed to send mails from this ID."
-msgstr "Només els usuaris d'aquests grups poden enviar correus des d'aquest compte."
+"Copy and paste the value in the location you want to use a system value."
+msgstr "Copieu i enganxeu el valor en la ubicació que voleu utilitzar un valor del sistema."
 
 #. module: poweremail
-#: field:poweremail.core_accounts,name:0
-msgid "Email Account Desc"
-msgstr "Descripció compte de correu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:185
-#, python-format
-msgid "No recipient: Email cannot be sent"
-msgstr "Sense destinatari: el correu no es pot enviar"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:679
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
 msgid "Copy of template "
 msgstr "Copia de la plantilla"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
-msgid "All emails"
-msgstr "Tots els correus"
+#: help:poweremail.templates,table_html:0
+msgid ""
+"Copy this html code to your HTML message body for displaying the info in "
+"your mail."
+msgstr "Copieu aquest codi HTML en el cos del missatge HTML per a mostrar la informació al vostre correu electrònic."
 
 #. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Discard Mail"
-msgstr "Cancel·la"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Drafts"
-msgstr "Esborranys"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:249
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Not valid destiny email"
-msgstr "Correu de destí no vàlid"
+msgid "Core connection for the given ID does not exist"
+msgstr "La connexió bàsica per l'ID donat no existeix"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_to:0 field:poweremail.templates,def_to:0
-msgid "Recepient (To)"
-msgstr "Per a"
+#: help:poweremail.templates,server_action:0
+msgid "Corresponding server action is here."
+msgstr "L'acció de servidor corresponent està aquí."
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Body (HTML-Web Client Only)"
-msgstr "Cos del missatge (HTML - Només client web)"
-
-#. module: poweremail
-#: field:poweremail.templates,use_filter:0
-msgid "Active Filter"
-msgstr "Filtre actiu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:270
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "%s account not found"
-msgstr "%s compte no trobat"
+msgid ""
+"Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
+"Description: {error}"
+msgstr "No s'ha pogut crear el correu \"{subject}\" desde el compte \"{account.name}\".\nDescripció: {error}"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1313
-#: code:addons/poweremail/poweremail_core.py:1317
-#, python-format
-msgid "Folder Error"
-msgstr "Error carpeta"
-
-#. module: poweremail
-#: field:poweremail.templates,table_html:0
-msgid "HTML code"
-msgstr "Codi HTML"
+#: help:poweremail.templates,send_on_create:0
+msgid ""
+"Create an e-mail when a new record is created. The instance where the record"
+" is created must be restarted for the changes to take effect."
+msgstr "Crear un correu electrònic quan es creï un registre nou. La instància on es crea el registre s’ha de reiniciar perquè els canvis tinguin efecte."
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "context - current context"
-msgstr "context - context actual"
+msgid "Create send email wizard"
+msgstr "Crear assistent d'enviament de correu"
+
+#. module: poweremail
+#: field:poweremail.mailbox,create_date:0
+msgid "Created date"
+msgstr "Data de creació"
+
+#. module: poweremail
+#: field:poweremail.mailbox,write_date:0
+msgid "Date modified"
+msgstr "Data de modificació"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Datetime Extraction failed. Date: %s\n"
+"Error: %s"
+msgstr "Ha fallat l'extracció de Data-Hora. Data: %s\nError: %s"
+
+#. module: poweremail
+#: field:poweremail.templates,def_bcc:0
+msgid "Default BCC"
+msgstr "BCC per defecte"
 
 #. module: poweremail
 #: field:poweremail.templates,def_cc:0
@@ -552,21 +507,312 @@ msgid "Default CC"
 msgstr "CC per defecte"
 
 #. module: poweremail
-#: help:poweremail.templates,def_cc:0
-msgid "The default CC for the email. Placeholders can be used here."
-msgstr "El CC per defecte del correu electrònic. Es poden usar expressions de camps."
+#: field:poweremail.templates,def_subject:0
+msgid "Default Subject"
+msgstr "Assumpte per defecte"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:935
+#: field:poweremail.templates,def_priority:0
+msgid "Default priority"
+msgstr "Prioritat per defecte"
+
+#. module: poweremail
+#: help:poweremail.templates,def_priority:0
+msgid "Default priority for auto generated emails"
+msgstr "Prioritat per defecte pels correus generats automàticament"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "Attachment to mail for %s relation failed Account: %s."
-msgstr "Adjunt de correu per la relació %s ha fallat. Compte: %s."
+msgid "Deletion of Record failed"
+msgstr "L'eliminació del registre ha fallat"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
-msgid "Mailbox: Followup"
-msgstr "Safata: Seguiment"
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
+msgid "Demo email subject for user ${object.login}"
+msgstr "Assumpte de correu de demostració per a l'usuari ${object.login}"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Discard Mail"
+msgstr "Cancel·la"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Django templates not installed"
+msgstr "Les plantilles Django no estan instal·lades"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr "No descarrega els adjunts automàticament"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Download Full Mail"
+msgstr "Descarrega tot el correu"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Downloaded & saved %s attachments Account: %s."
+msgstr "Descarregats i desats %s adjunts. Compte: %s."
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts_company
+msgid "Drafts"
+msgstr "Esborranys"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Dynamic attachments (reports)"
+msgstr "Adjunts dinàmics (informes)"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Editor (HTML)"
+msgstr "Editor (HTML)"
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,name:0
+msgid "Email Account"
+msgstr "Compte de correu"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,name:0
+msgid "Email Account Desc"
+msgstr "Descripció compte de correu"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
+msgid "Email Basic Templates"
+msgstr "Plantilles de correu bàsiques"
+
+#. module: poweremail
+#: view:ir.actions.server:0
+msgid "Email Configuration"
+msgstr "Configuració correu electrònic"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,email_id:0
+msgid "Email ID"
+msgstr "ID correu electrònic"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
+msgid "Email Mailbox Conversation"
+msgstr "Conversa"
+
+#. module: poweremail
+#: field:ir.actions.report.xml,poweremail_template_ids:0
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
+msgid "Email Templates"
+msgstr "Plantilles de correu electrònic"
+
+#. module: poweremail
+#: field:poweremail.preview,enforce_from_account:0
+msgid "Email account"
+msgstr "Compte de correu"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Email body"
+msgstr "Cos del correu electrònic"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Email sending failed for one or more objects."
+msgstr "L'enviament de correu ha fallat en un o varis objectes."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Email sent successfully"
+msgstr "Email enviat correctament"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Email will be sent again"
+msgstr "El correu es tornarà a enviar"
+
+#. module: poweremail
+#: help:poweremail.preview,enforce_from_account:0
+msgid "Email will be sent from this account."
+msgstr "El correu s’enviarà des d’aquest compte."
+
+#. module: poweremail
+#: view:wizard.change.state.email:0
+msgid "Emails canviats d'estat!"
+msgstr "Emails canviats d'estat!"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0
+msgid "Emails canviats de carpeta!"
+msgstr "Emails canviats de safata!"
+
+#. module: poweremail
+#: help:poweremail.templates,send_immediately:0
+msgid ""
+"Emails created from this template will be sent immediately without going "
+"through outbox folder."
+msgstr "Els correus creats a partir d'aquesta plantilla s'enviaran immediatament sense passar per la safata de sortida."
+
+#. module: poweremail
+#: view:wizard.send.email:0
+msgid "Emails enviats!"
+msgstr "Emails enviats!"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Emails for multiple items saved in outbox."
+msgstr "Correus per a múltiples elements guardats a la bústia de sortida."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
+msgid "Emails in error folder"
+msgstr "Correus a la carpeta d'errors"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
+msgid "Emails sent"
+msgstr "Correus enviats"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
+msgid "Emails sent today"
+msgstr "Correus enviats avui"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
+msgid "Emails to sent"
+msgstr "Correus per enviar"
+
+#. module: poweremail
+#: help:poweremail.templates,enforce_from_account:0
+msgid "Emails will be sent only from this account."
+msgstr "Els correus electrònics s'enviaran només des d'aquest compte."
+
+#. module: poweremail
+#: selection:poweremail.preview,state:0
+#: selection:wizard.change.folder.email,state:0
+#: selection:wizard.change.state.email,wiz_state:0
+#: selection:wizard.send.email,state:0
+msgid "End"
+msgstr "Fi"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Endavant"
+msgstr "Endavant"
+
+#. module: poweremail
+#: field:poweremail.templates,enforce_from_account:0
+msgid "Enforce From Account"
+msgstr "Força des del compte"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,iserver:0
+msgid "Enter name of incoming server, eg: imap.gmail.com"
+msgstr "Introduïu el nom del servidor de correu d'entrada, per exemple: imap.gmail.com"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpserver:0
+msgid "Enter name of outgoing server, eg: smtp.gmail.com"
+msgstr "Escriviu el nom del servidor de correu de sortida, per exemple: smtp.gmail.com"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
+msgstr "Introduïu el port, per exemple per SMTP 587."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
+#: view:wizard.send.email:0
+msgid "Enviar emails"
+msgstr "Enviar emails"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_serveraction.py:0
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
+#: selection:poweremail.preview,state:0
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error receiving mail: %s"
+msgstr "Error rebent correu: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending email with id {}: {}"
+msgstr "Error enviat el correu amb id {}: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending mail: %s"
+msgstr "Error enviant correu: %s"
+
+#. module: poweremail
+#: constraint:poweremail.core_accounts:0
+msgid "Error: You are not allowed to have more than 1 account."
+msgstr "Error: No té permès tenir més d'1 compte."
+
+#. module: poweremail
+#: field:wizard.change.state.email,estat:0
+msgid "Estat"
+msgstr "Estat"
+
+#. module: poweremail
+#: field:poweremail.templates,copyvalue:0
+msgid "Expression"
+msgstr "Expressió"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Expression builder"
+msgstr "Generador d'expressions"
+
+#. module: poweremail
+#: field:poweremail.preview,env:0 view:poweremail.preview:0
+msgid "Extra scope variables"
+msgstr "Variables extres de l'àmbit (scope)"
+
+#. module: poweremail
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
+msgid "Factura ${object.number}"
+msgstr "Factura ${object.number}"
+
+#. module: poweremail
+#: field:poweremail.templates,model_object_field:0
+msgid "Field"
+msgstr "Camp"
+
+#. module: poweremail
+#: field:poweremail.templates,file_name:0
+msgid "File Name Pattern"
+msgstr "Patró nom de fitxer"
+
+#. module: poweremail
+#: field:poweremail.template.attachment,file_name:0
+msgid "File name"
+msgstr "Nom del fitxer"
 
 #. module: poweremail
 #: help:poweremail.templates,file_name:0
@@ -575,10 +821,490 @@ msgid ""
 msgstr "Patró del nom de fitxer. Es pot especificar amb expressions de camps. Exemple: ${object.name}.pdf generaria 2009_SO003.pdf"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:933
+#: field:poweremail.templates,filter:0 view:poweremail.templates:0
+msgid "Filter"
+msgstr "Filtre"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Finalitzar"
+msgstr "Finalitzar"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,rec_headers_den_mail:0
+msgid "First Receive headers, then download mail"
+msgstr "Primer es descarreguen les capçaleres, després el correu"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isfolder:0 field:poweremail.mailbox,folder:0
+#: field:wizard.change.folder.email,folder:0
+msgid "Folder"
+msgstr "Carpeta"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Attachment to mail for %s relation success! Account: %s."
-msgstr "Adjunt de correu per la relació %s correcte! Compte: %s."
+msgid "Folder Error"
+msgstr "Error carpeta"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isfolder:0
+msgid ""
+"Folder to be used for downloading IMAP mails.\n"
+"Click on adjacent button to select from a list of folders."
+msgstr "Carpeta a usar per rebre els correus IMAP.\nSeleccioneu-la de la llista de carpetes fent clic al botó."
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
+msgid "Follow-up"
+msgstr "Seguiment"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isport:0
+msgid "For example IMAP: 993,POP3:995"
+msgstr "Per exemple IMAP: 993, POP3: 995."
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_from:0
+msgid "From"
+msgstr "Des de"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,from:0
+msgid "From Account"
+msgstr "Des del compte"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "From Poweremail Mailbox {} Original email as {}"
+msgstr "Desde Safata {} Correu original com {}"
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "Generated Email"
+msgstr "Correu generat"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Get Mail"
+msgstr "Recupera missatges"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "HTML Body"
+msgstr "Cos del missatge HTML"
+
+#. module: poweremail
+#: field:poweremail.templates,table_html:0
+msgid "HTML code"
+msgstr "Codi HTML"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "HTML otherwise Text"
+msgstr "HTML, en cas contrari Text"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Has Attachments"
+msgstr "Té adjunts"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
+msgstr "Capçalera del correu %s desada correctament amb ID: %s pel compte: %s."
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "High"
+msgstr "Alta"
+
+#. module: poweremail
+#: field:poweremail.mailbox,history:0
+msgid "History"
+msgstr "Historial"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "IMAP"
+msgstr "IMAP"
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,folder:0
+msgid "IMAP Folder"
+msgstr "Carpeta IMAP"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
+msgid "IMAP Folder Selection Wizard"
+msgstr "Assistent selecció carpeta IMAP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder Statistics for Account: %s: %s"
+msgstr "Estadístiques de carpeta IMAP pel compte: %s: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account: %s."
+msgstr "Carpeta IMAP seleccionada correctament. Compte: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account:%s."
+msgstr "Carpeta IMAP seleccionada correctament. Compte:%s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
+msgstr "Correu IMAP -> Error al crear bústia. Compte: %s, Correu: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
+msgstr "Correu IMAP -> Error en crear bústia. Compte: %s, Correu: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Connected & logged in successfully Account: %s."
+msgstr "Servidor IMAP connectat i autenticat correctament. Compte: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Error: {}"
+msgstr "Error del servidor IMAP: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Error"
+msgstr "Error carpeta servidor IMAP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
+msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"IMAP Server Folder Selection Error Account: %s Error: %s.\n"
+"Check account settings if you have selected a folder."
+msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s.\nComproveu si heu seleccionat una carpeta a la configuració del compte."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
+msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Login Error: {}"
+msgstr "Error de login al servidor IMAP: {}"
+
+#. module: poweremail
+#: help:poweremail.templates,inline:0
+msgid "If the option is checked, the CSS will be inlined inside the HTML"
+msgstr "Si es marca l'opció, el CSS s'incrustarà als elements HTML"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "In coming connection test failed"
+msgstr "El test de la connexió d'entrada ha fallat"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
+msgid "Inbox"
+msgstr "Entrada"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
+msgid "Inbox Conversations"
+msgstr "Converses"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Incoming"
+msgstr "Entrada"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,iserver:0
+msgid "Incoming Server"
+msgstr "Servidor d'entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming Test Connection Was Successful"
+msgstr "El test de la connexió d'entrada ha estat un èxit"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming port is not defined"
+msgstr "No s'ha definit el port d'entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server is not defined"
+msgstr "No s'ha definit el servidor d'entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Incoming server login attempt dropped Account: %s\n"
+"Check if Incoming server attributes are complete."
+msgstr "Intent d'autenticació amb el servidor d'entrada avortat. Compte: %s.\nComproveu si les dades del servidor d'entrada estan complertes."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Incoming server login attempt dropped Account: %s Check if Incoming server "
+"attributes are complete."
+msgstr "Intent d'autenticació amb el servidor d'entrada avortat. Compte: %s. Comproveu si les dades del servidor d'entrada estan complertes."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server password is not defined"
+msgstr "No s'ha definit la contrasenya del servidor d'entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server user name is not defined"
+msgstr "No s'ha definit el nom de l'usuari del servidor d'entrada"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Information"
+msgstr "Informació"
+
+#. module: poweremail
+#: selection:poweremail.preview,state:0
+#: selection:wizard.change.folder.email,state:0
+#: selection:wizard.change.state.email,wiz_state:0
+#: selection:wizard.send.email,state:0
+msgid "Init"
+msgstr "Init"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,state:0
+msgid "Initiated"
+msgstr "Iniciat"
+
+#. module: poweremail
+#: field:poweremail.templates,inline:0
+msgid "Inline HTML"
+msgstr "Inline HTML"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Insert Simple Field"
+msgstr "Insereix camp simple"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Insert Table"
+msgstr "Insereix taula"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Intermixed content"
+msgstr "Contingut variat"
+
+#. module: poweremail
+#: constraint:ir.ui.view:0
+msgid ""
+"Invalid XML for View Architecture! Check server logs for details (view name,"
+" model, line number and RNG error)."
+msgstr "XML no vàlid per a l'arquitectura de la vista! Revisa els registres del servidor per obtenir més detalls (nom de la vista, model, número de línia i error RNG)."
+
+#. module: poweremail
+#: constraint:ir.cron:0
+msgid "Invalid arguments"
+msgstr "Invalid arguments"
+
+#. module: poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr "Nom del model invàlid en la definició de l'acció."
+
+#. module: poweremail
+#: field:poweremail.preview,lang:0 field:poweremail.templates,lang:0
+msgid "Language"
+msgstr "Idioma"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,last_mail_id:0
+msgid "Last Downloaded Mail"
+msgstr "Darrera descàrrega de correu"
+
+#. module: poweremail
+#: field:poweremail.templates,last_send_date:0
+msgid "Last Sent Date"
+msgstr "Data de l'últim enviament"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
+msgstr "Llistar correus relacionats"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Log partner events"
+msgstr "Registrar correus com esdeveniments d'empresa"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Logs"
+msgstr "Registres"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Low"
+msgstr "Baixa"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail %s Saved successfully as ID: %s for Account: %s."
+msgstr "Correu %s desat correctament com ID: %s pel compte: %s."
+
+#. module: poweremail
+#: field:poweremail.mailbox,mail_type:0
+msgid "Mail Contents"
+msgstr "Contingut del correu electrònic"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Mail Details"
+msgstr "Detalls del correu electrònic"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,send_pref:0
+msgid "Mail Format"
+msgstr "Format del correu electrònic"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Mail fetch exception"
+msgstr "Excepció d'extracció de correu"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
+"Error: %s"
+msgstr "Correu des del compte %s ha fallat a l'autenticació. Motiu probable: No es pot autenticar amb el servidor.\nError: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail from Account %s failed. Probable Reason: Account not approved"
+msgstr "Correu des del compte %s ha fallat. Motiu probable: Compte no aprovat."
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
+msgid "MailBox"
+msgstr "Bústia"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
+msgstr "Bústia: Tots els correus"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
+msgid "Mailbox: Drafts"
+msgstr "Safata: Esborranys"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
+msgid "Mailbox: Error"
+msgstr "Safata: Error"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
+msgid "Mailbox: Followup"
+msgstr "Safata: Seguiment"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree_company
+msgid "Mailbox: Inbox"
+msgstr "Safata: Entrada"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
+msgid "Mailbox: Outbox"
+msgstr "Safata: Sortida"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
+msgid "Mailbox: Sending"
+msgstr "Bústia: Enviant"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
+msgid "Mailbox: Sent"
+msgstr "Safata: Enviats"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
+msgid "Mailbox: Trash"
+msgstr "Safata: Paperera"
+
+#. module: poweremail
+#: selection:poweremail.templates,template_language:0
+msgid "Mako Templates"
+msgstr "Plantilles Mako"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Mako templates not installed"
+msgstr "Les plantilles Mako no estan instal·lades"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_message_id:0
+msgid "Message-Id"
+msgstr "Message-Id"
 
 #. module: poweremail
 #: field:poweremail.send.wizard,rel_model:0
@@ -588,55 +1314,156 @@ msgid "Model"
 msgstr "Model"
 
 #. module: poweremail
-#: help:poweremail.templates,table_sub_object:0
-msgid "This field shows the model you will be using for your table."
-msgstr "Aquest camp mostra el model que s'utilitzarà en la vostra taula."
+#: help:poweremail.templates,model_data_name:0
+msgid "Model Data Name."
+msgstr "Nom de les dades del model."
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_send_wizard
-msgid "This is the wizard for sending mail"
-msgstr "Aquest és l'assistent per enviar el correu electrònic"
+#: field:poweremail.templates,model_int_name:0
+msgid "Model Internal Name"
+msgstr "Nom del model intern"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_all
-msgid "All Accounts"
-msgstr "Tots els comptes"
+#: view:poweremail.templates:0
+msgid "More information"
+msgstr "Més informació"
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Check Outgoing Connection"
-msgstr "Comprova la connexió de sortida"
+#: selection:poweremail.send.wizard,state:0
+msgid "Multiple Mail Wizard Step 1"
+msgstr "Assistent correus múltiples - Pas 1"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,last_mail_id:0
-msgid "Last Downloaded Mail"
-msgstr "Darrera descàrrega de correu"
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
+msgid "My Account"
+msgstr "El meu compte"
 
 #. module: poweremail
-#: field:poweremail.templates,stats_interval:0
-msgid "Stats Interval"
-msgstr "Interval d'estadístiques"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
+msgid "My Accounts"
+msgstr "Els meus comptes"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1318
+#: field:poweremail.conversation,name:0
+msgid "Name"
+msgstr "Nom"
+
+#. module: poweremail
+#: field:poweremail.templates,name:0
+msgid "Name of Template"
+msgstr "Nom de la plantilla"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,company:0
+msgid "No"
+msgstr "No"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
-msgid "Select a folder before you save record"
-msgstr "Seleccioneu una carpeta abans de desar el registre"
+msgid "No Description"
+msgstr "No hi ha descripció"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:774
-#: code:addons/poweremail/poweremail_core.py:848
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr "Capçalera del correu %s desada correctament amb ID: %s pel compte: %s."
+msgid "No Subject"
+msgstr "No hi ha assumpte"
 
 #. module: poweremail
-#: help:poweremail.templates,filter:0
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No information on which mail should be fetched fully"
+msgstr "No existeix informació sobre quin correu hauria de ser extret completament"
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "No model reference defined"
+msgstr "No s’ha definit cap referència de model"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
+msgstr "Nº de correus generats"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,requested:0
+msgid "No of requested Mails"
+msgstr "Número de missatges sol·licitats"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
 msgid ""
-"The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
-"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
-msgstr "El codi python introduït ací serà executat. Si el resultat és True el correu serà enviat, si és False no serà enviat.\nExemple : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
+"No personal email accounts are configured for you. \n"
+"Either ask admin to enforce an account for this template or get yourself a personal power email account."
+msgstr "No s'us han configurat comptes de correu personals.\nSol·liciteu a l'administrador que us proporcioni un compte per aquesta plantilla o obtingueu un compte de correu personal de poweremail."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No recipient: Email cannot be sent"
+msgstr "Sense destinatari: el correu no es pot enviar"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Normal"
+msgstr "Normal"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Not Applicable"
+msgstr "No aplicable"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Not valid destiny email"
+msgstr "Correu de destí no vàlid"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Note: HTML body can't be edited with GTK desktop client."
+msgstr "Nota: El cos HTML no es pot editar amb el client de escriptori GTK."
+
+#. module: poweremail
+#: field:poweremail.templates,null_value:0
+msgid "Null Value"
+msgstr "Valor nul"
+
+#. module: poweremail
+#: help:poweremail.templates,stats_interval:0
+msgid ""
+"Number of days used to calculate the send count backwards from today. If "
+"empty or zero, all sent emails are taken into account."
+msgstr "Nombre de dies utilitzats per calcular el nombre d'enviaments cap enrere des d'avui. Si està buit o és zero, es tenen en compte tots els correus enviats."
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "OK"
+msgstr "OK"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Ok"
+msgstr "D'acord"
+
+#. module: poweremail
+#: help:poweremail.templates,record_attachment_categories:0
+msgid ""
+"Only attach record attachments with the included categories in case there's "
+"any."
+msgstr "Adjuntar únicament els adjunts del registre amb les categories incloses si és que n'hi ha alguna."
+
+#. module: poweremail
+#: help:poweremail.core_accounts,allowed_groups:0
+msgid ""
+"Only users from these groups will be allowed to send mails from this ID."
+msgstr "Només els usuaris d'aquests grups poden enviar correus des d'aquest compte."
 
 #. module: poweremail
 #: help:poweremail.templates,allowed_groups:0
@@ -646,178 +1473,302 @@ msgid ""
 msgstr "Només els usuaris d'aquests grups poden enviar correus des d'aquesta plantilla."
 
 #. module: poweremail
-#: help:poweremail.templates,auto_email:0
-msgid ""
-"Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
-"Note: Auto email can be enabled only after saving template."
-msgstr "Si seleccioneu correu electrònic automàtic es crearà una acció de servidor perquè s'enviï el correu després de crear-se/actualitzar-se un registre.\nAtenció: Es pot activar el correu automàtic només desprès de desar la plantilla."
+#: view:poweremail.templates:0
+msgid "OpenObject Code Filter:"
+msgstr "OpenObject Code Filter:"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:340
-#: code:addons/poweremail/poweremail_core.py:350
-#: code:addons/poweremail/poweremail_core.py:456
-#: code:addons/poweremail/poweremail_core.py:461
-#: code:addons/poweremail/poweremail_core.py:593
-#: code:addons/poweremail/poweremail_core.py:641
-#: code:addons/poweremail/poweremail_core.py:651
-#: code:addons/poweremail/poweremail_core.py:708
-#: code:addons/poweremail/poweremail_core.py:751
-#: code:addons/poweremail/poweremail_core.py:765
-#: code:addons/poweremail/poweremail_core.py:772
-#: code:addons/poweremail/poweremail_core.py:780
-#: code:addons/poweremail/poweremail_core.py:836
-#: code:addons/poweremail/poweremail_core.py:846
-#: code:addons/poweremail/poweremail_core.py:861
-#: code:addons/poweremail/poweremail_core.py:901
-#: code:addons/poweremail/poweremail_core.py:904
-#: code:addons/poweremail/poweremail_core.py:913
-#: code:addons/poweremail/poweremail_core.py:930
-#: code:addons/poweremail/poweremail_core.py:933
-#: code:addons/poweremail/poweremail_core.py:935
-#: code:addons/poweremail/poweremail_core.py:946
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:958
-#: code:addons/poweremail/poweremail_core.py:959
-#: code:addons/poweremail/poweremail_core.py:960
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1011
-#: code:addons/poweremail/poweremail_core.py:1029
-#: code:addons/poweremail/poweremail_core.py:1048
-#: code:addons/poweremail/poweremail_core.py:1059
-#: code:addons/poweremail/poweremail_core.py:1070
-#: code:addons/poweremail/poweremail_core.py:1076
-#: code:addons/poweremail/poweremail_core.py:1082
-#: code:addons/poweremail/poweremail_core.py:1121
-#: code:addons/poweremail/poweremail_core.py:1132
-#: code:addons/poweremail/poweremail_core.py:1138
-#: code:addons/poweremail/poweremail_core.py:1144
-#: code:addons/poweremail/poweremail_core.py:1152
-#: code:addons/poweremail/poweremail_mailbox.py:60
-#: code:addons/poweremail/poweremail_mailbox.py:67
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#: code:addons/poweremail/poweremail_send_wizard.py:275
-#: code:addons/poweremail/poweremail_template.py:54
-#: code:addons/poweremail/poweremail_template.py:68
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr "Correu original"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Other settings"
+msgstr "Altres configuracions"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company_others
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal_others
+msgid "Others"
+msgstr "Altres"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Out going connection test failed"
+msgstr "El test de la connexió de sortida ha fallat"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
+msgid "Outbox"
+msgstr "Sortida"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Outgoing"
+msgstr "Sortida"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "POP3"
+msgstr "POP3"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Connected & logged in successfully Account: %s."
+msgstr "Servidor POP3 connectat i autenticat correctament. Compte: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Error Account: %s Error: %s."
+msgstr "Error del servidor POP3 al compte %s. Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Login Error Account: %s Error: %s."
+msgstr "Error d'autenticació servidor POP3. Compte: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s"
+msgstr "Estadístiques POP3: %s correus de grandària %s pel compte: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
+msgstr "Estadístiques POP3: %s correus de grandària %s pel compte: %s:"
+
+#. module: poweremail
+#: field:poweremail.templates,partner_event:0
+msgid "Partner ID to log Events"
+msgstr "ID empresa per a registrar esdeveniments"
+
+#. module: poweremail
+#: help:poweremail.templates,partner_event:0
+msgid ""
+"Partner ID who an email event is logged.\n"
+"Placeholders can be used here. eg. ${object.partner_id.id}\n"
+"You must install the mail_gateway module to see the mail events in partner form.\n"
+"If you also want to record the link to the object that sends the email, you must to add this object in the 'Administration/Low Level Objects/Requests/Accepted Links in Requests' menu (or 'ir.attachment' to record the attachments)."
+msgstr "ID d'empresa a on s'ha de registrar un esdeveniment de correu.\nEs pot usar expressions de camps. Per ex. ${object.partner_id.id}\nHeu d'instal·lar el mòdul mail_gateway per veure els esdeveniments de correu en el formulari d'empresa.\nSi també voleu desar l'enllaç cap a l'objecte que envia el correu, heu d'afegir aquest objecte des del menú 'Administració/Personalització/Objectes de baix nivell/Sol·licituds/Tipus de referències en sol·licituds' (o 'ir.attachment' per desar els adjunts)."
+
+#. module: poweremail
+#: field:poweremail.core_accounts,ispass:0
+#: field:poweremail.core_accounts,smtppass:0
+msgid "Password"
+msgstr "Contrasenya"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
+msgid "Personal"
+msgstr "Personal"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
+msgid "Personal Account"
+msgstr "Compte personal"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
+msgid "Personal Accounts"
+msgstr "Comptes personals"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Plain Text"
+msgstr "Text pla"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Plain Text & HTML with no attachments"
+msgstr "Text pla i HTML sense adjunts"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_serveraction.py:0
+#, python-format
+msgid "Please specify an template to use for auto email in poweremail!"
+msgstr "Indiqueu una plantilla per usar pels correus automàtics a poweremail!"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isport:0
+msgid "Port"
+msgstr "Port"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#: code:addons/poweremail/poweremail_template.py:0
 #: model:ir.ui.menu,name:poweremail.menu_poweremail_administration_server
 #, python-format
 msgid "Power Email"
 msgstr "Power Email"
 
 #. module: poweremail
-#: help:poweremail.templates,lang:0
-msgid ""
-"The default language for the email. Placeholders can be used here. eg. "
-"${object.partner_id.lang}"
-msgstr "L'idioma per defecte del correu electrònic. Es poden usar expressions de camps, per ex. ${object.partner_id.lang}"
+#: view:poweremail.mailbox:0
+msgid "Power Email All Emails"
+msgstr "Tots els correus"
 
 #. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Get Mail"
-msgstr "Recupera missatges"
+#: view:poweremail.core_accounts:0
+msgid "Power Email Configuration"
+msgstr "Configuració"
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Log partner events"
-msgstr "Registrar correus com esdeveniments d'empresa"
+#: view:poweremail.conversation:0
+msgid "Power Email Conversation"
+msgstr "Converses"
 
 #. module: poweremail
-#: field:poweremail.preview,body_html:0 field:poweremail.preview,body_text:0
-#: field:poweremail.send.wizard,body_html:0
-#: field:poweremail.send.wizard,body_text:0
-msgid "Body"
-msgstr "Cos del missatge"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts_company
-msgid "Drafts"
+#: view:poweremail.mailbox:0
+msgid "Power Email Drafts"
 msgstr "Esborranys"
 
 #. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Error"
+msgstr "Error de Power Email"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Follow Up"
+msgstr "Seguiment PowerEmail"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Inbox"
+msgstr "Entrada"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_mailbox
+msgid "Power Email Mailbox included all type inbox,outbox,junk.."
+msgstr "PowerMail inclou tot tipus de bústies de correu: entrada, sortida, brossa, ..."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Outbox"
+msgstr "Safata de Sortida"
+
+#. module: poweremail
 #: view:poweremail.preview:0
-msgid "Send Email"
-msgstr "Enviar correu"
+msgid "Power Email Preview"
+msgstr "Vista prèvia"
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "SMTP Server"
-msgstr "Servidor SMTP"
+#: view:poweremail.mailbox:0
+msgid "Power Email Sent"
+msgstr "Enviat"
 
 #. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send all mails"
-msgstr "Envia tots els correus"
+#: model:ir.model,name:poweremail.model_poweremail_preview
+msgid "Power Email Template Preview"
+msgstr "Previsualització de la plantilla"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,iserver_type:0
-msgid "Server Type"
-msgstr "Tipus de servidor"
+#: view:poweremail.templates:0
+msgid "Power Email Templates"
+msgstr "Plantilles de correu electrònic"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree_company
-msgid "Mailbox: Inbox"
-msgstr "Safata: Entrada"
+#: model:ir.model,name:poweremail.model_poweremail_templates
+msgid "Power Email Templates for Models"
+msgstr "Plantilles per als models"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:401
-#, python-format
-msgid "Incoming port is not defined"
-msgstr "No s'ha definit el port d'entrada"
+#: view:poweremail.mailbox:0
+msgid "Power Email Trash"
+msgstr "Paperera"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1018
+#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
+msgid "Poweremail scheduler"
+msgstr "Planificador de poweremail"
+
+#. module: poweremail
+#: model:ir.module.module,shortdesc:poweremail.module_meta_information
+msgid "Powerful Email capabilities for Open ERP"
+msgstr "Funcionalitats de correu potents per a OpenERP"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Preview"
+msgstr "Vista prèvia"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Preview Email"
+msgstr "Vista prèvia del correu"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Preview Template"
+msgstr "Previsualitza plantilla"
+
+#. module: poweremail
+#: field:poweremail.mailbox,priority:0 field:poweremail.send.wizard,priority:0
+msgid "Priority"
+msgstr "Prioritat"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
 msgid ""
-"The expression in 'Reference of the report' field must contain the 'object' "
-"variable."
-msgstr "L'expressió del camp 'Referència de l'informe' ha de contenir la variable 'object'."
+"Programming Error in _get_pop3_server method. The record received is "
+"invalid."
+msgstr "Error de programació en el mètode _get_pop3_server. El registre que s'ha rebut no és vàlid."
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:275
+#: view:poweremail.mailbox:0
+msgid "Raw content"
+msgstr "Contingut brut (raw)"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Read"
+msgstr "Llegit"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Email sending failed for one or more objects."
-msgstr "L'enviament de correu ha fallat en un o varis objectes."
+msgid "Reason: %s"
+msgstr "Motiu: %s"
 
 #. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Send Type"
-msgstr "Tipus d'enviament"
+#: field:poweremail.mailbox,date_mail:0
+msgid "Rec/Sent Date"
+msgstr "Data recepció/enviament"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1029
-#, python-format
-msgid ""
-"Incoming server login attempt dropped Account: %s Check if Incoming server "
-"attributes are complete."
-msgstr "Intent d'autenticació amb el servidor d'entrada avortat. Compte: %s. Comproveu si les dades del servidor d'entrada estan complertes."
+#: field:poweremail.mailbox,pem_recd:0
+msgid "Received at"
+msgstr "Rebut el"
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Approve Account"
-msgstr "Aprova el compte"
+#: field:poweremail.mailbox,pem_to:0 field:poweremail.templates,def_to:0
+msgid "Recepient (To)"
+msgstr "Per a"
+
+#. module: poweremail
+#: field:poweremail.templates,record_attachment_categories:0
+msgid "Record attachment categories"
+msgstr "Categories dels adjunts dels registres"
+
+#. module: poweremail
+#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
+msgid "Reenviar emails amb error"
+msgstr "Reenviar correus amb error"
 
 #. module: poweremail
 #: field:poweremail.send.wizard,rel_model_ref:0
 msgid "Referred Document"
-msgstr "Document relacionat"
-
-#. module: poweremail
-#: help:poweremail.templates,def_to:0
-msgid "The default recepient of email. Placeholders can be used here."
-msgstr "El destinatari per defecte del correu electrònic. Es poden usar expressions de camps."
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,pem_body_text:0
-#: field:poweremail.templates,def_body_text:0
-msgid "Standard Body (Text)"
-msgstr "Cos del missatge (Text)"
+msgstr "Document de referència"
 
 #. module: poweremail
 #: field:poweremail.conversation,mails:0
@@ -830,240 +1781,25 @@ msgid "Related Server Action"
 msgstr "Acció de servidor relacionada"
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_mailbox
-msgid "Power Email Mailbox included all type inbox,outbox,junk.."
-msgstr "PowerMail inclou tot tipus de bústies de correu: entrada, sortida, brossa, ..."
+#: field:poweremail.core_accounts,user:0
+msgid "Related User"
+msgstr "Usuari relacionat"
 
 #. module: poweremail
-#: field:poweremail.preview,subject:0 field:poweremail.send.wizard,subject:0
-msgid "Subject"
-msgstr "Subjecte"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:403
-#, python-format
-msgid "Incoming server user name is not defined"
-msgstr "No s'ha definit el nom de l'usuari del servidor d'entrada"
-
-#. module: poweremail
-#: selection:poweremail.preview,state:0
-#: selection:wizard.change.folder.email,state:0
-#: selection:wizard.change.state.email,wiz_state:0
-#: selection:wizard.send.email,state:0
-msgid "End"
-msgstr "Fi"
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar emails"
-msgstr "Buscar correus"
-
-#. module: poweremail
-#: help:poweremail.templates,send_on_write:0
-msgid "Sends an e-mail when a document is modified."
-msgstr "Envia un correu electrònic quan es modifica un document."
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Follow Up"
-msgstr "Seguiment PowerEmail"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Standard Body"
-msgstr "Cos del missatge (estàndard)"
+#: view:ir.actions.report.xml:0
+msgid "Related email templates"
+msgstr "Plantilles de correu relacionades"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Email body"
-msgstr "Cos del correu electrònic"
+msgid "Remove send email wizard"
+msgstr "Eliminar assistent d'enviament de correu"
 
 #. module: poweremail
-#: field:poweremail.templates,name:0
-msgid "Name of Template"
-msgstr "Nom de la plantilla"
-
-#. module: poweremail
-#: field:poweremail.templates,send_count:0
-msgid "Send Count"
-msgstr "Nombre d'enviaments"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:334
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
 msgid "Report"
 msgstr "Informe"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:642
-#, python-format
-msgid ""
-"Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
-"Description: {error}"
-msgstr "No s'ha pogut crear el correu \"{subject}\" desde el compte \"{account.name}\".\nDescripció: {error}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:316
-#: code:addons/poweremail/poweremail_core.py:436
-#, python-format
-msgid "Reason: %s"
-msgstr "Motiu: %s"
-
-#. module: poweremail
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr "XML invàlid per a l'estructura de la vista!"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_preview
-msgid "Power Email Template Preview"
-msgstr "Previsualització de la plantilla"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtptls:0
-msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
-msgstr "Establir una connexió TLS després de la connexió SMTP (normalment port 587)"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Body (Plain Text)"
-msgstr "Cos del missatge (Text pla)"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Outbox"
-msgstr "Safata de Sortida"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:310
-#, python-format
-msgid "SMTP Test Connection Was Successful"
-msgstr "El test de la connexió SMTP ha estat un èxit"
-
-#. module: poweremail
-#: field:poweremail.conversation,from_abstract:0
-msgid "unknown"
-msgstr "desconegut"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,company:0
-msgid "Company Mail A/c"
-msgstr "Compte correu de la companyia"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1144
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
-msgstr "Estadístiques POP3: %s correus de grandària %s pel compte: %s:"
-
-#. module: poweremail
-#: help:poweremail.templates,use_filter:0
-msgid ""
-"This option allow you to add a custom python filter before sending a mail"
-msgstr "This option allow you to add a custom python filter before sending a mail"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_template_attachment
-msgid "poweremail.template.attachment"
-msgstr "poweremail.template.attachment"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:913
-#, python-format
-msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
-msgstr "Correu IMAP -> Error al crear bústia. Compte: %s, Correu: %s"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send now"
-msgstr "Envia ara"
-
-#. module: poweremail
-#: help:poweremail.templates,report_template_object_reference:0
-msgid ""
-"The evaluation of this field should return the ID of the related object. For"
-" example, use: object.related_model_id.id. This ensures that the template "
-"can correctly reference the object."
-msgstr "L'avaluació d'aquest camp ha de retornar l'ID de l'objecte relacionat. Per exemple, utilitza: object.related_model_id.id. Això garanteix que la plantilla pugui referenciar correctament l'objecte."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
-msgid "Mailbox: Trash"
-msgstr "Safata: Paperera"
-
-#. module: poweremail
-#: field:poweremail.templates,model_int_name:0
-msgid "Model Internal Name"
-msgstr "Nom del model intern"
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body preview"
-msgstr "Vista prèvia"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:960
-#, python-format
-msgid "IMAP Folder selected successfully Account:%s."
-msgstr "Carpeta IMAP seleccionada correctament. Compte:%s."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Static attachments"
-msgstr "Adjunts estàtics"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Preview Template"
-msgstr "Previsualitza plantilla"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,isfolder:0
-msgid ""
-"Folder to be used for downloading IMAP mails.\n"
-"Click on adjacent button to select from a list of folders."
-msgstr "Carpeta a usar per rebre els correus IMAP.\nSeleccioneu-la de la llista de carpetes fent clic al botó."
-
-#. module: poweremail
-#: field:poweremail.send.wizard,from:0
-msgid "From Account"
-msgstr "Des del compte"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_templates
-msgid "Power Email Templates for Models"
-msgstr "Plantilles per als models"
-
-#. module: poweremail
-#: field:poweremail.preview,enforce_from_account:0
-msgid "Email account"
-msgstr "Compte de correu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:782
-#: code:addons/poweremail/poweremail_core.py:863
-#, python-format
-msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
-msgstr "Correu IMAP -> Error en crear bústia. Compte: %s, Correu: %s"
-
-#. module: poweremail
-#: field:poweremail.preview,lang:0 field:poweremail.templates,lang:0
-msgid "Language"
-msgstr "Idioma"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1268
-#: code:addons/poweremail/poweremail_core.py:1271
-#, python-format
-msgid "An error occurred: %s"
-msgstr "S'ha produït un error: %s"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:594
-#, python-format
-msgid "Cannot send mails of accounts {} when the addresses list is empty"
-msgstr "No es poden envair els correus dels comptes {} quan la llista d'adreces és buida"
 
 #. module: poweremail
 #: field:poweremail.send.wizard,report:0
@@ -1071,14 +1807,92 @@ msgid "Report File Name"
 msgstr "Nom del fitxer de l'informe"
 
 #. module: poweremail
-#: field:poweremail.templates,table_model_object_field:0
-msgid "Table Field"
-msgstr "Camp de la taula"
+#: field:poweremail.preview,report:0
+msgid "Report Name"
+msgstr "Nom de l’informe"
 
 #. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,history:0
-msgid "History"
-msgstr "Historial"
+#: field:poweremail.template.attachment,report_id:0
+#: field:poweremail.templates,report_template:0
+msgid "Report to send"
+msgstr "Informe per enviar"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Request Re-activation"
+msgstr "Sol.licita reactivació"
+
+#. module: poweremail
+#: field:poweremail.templates,table_required_fields:0
+msgid "Required Fields"
+msgstr "Camps requerits"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,smtpport:0
+msgid "SMTP Port "
+msgstr "Port SMTP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "SMTP SERVER or PORT not specified"
+msgstr "SERVIDOR SMTP o PORT no especificat"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "SMTP Server"
+msgstr "Servidor SMTP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "SMTP Test Connection Was Successful"
+msgstr "El test de la connexió SMTP ha estat un èxit"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
+msgstr "Desa capçalera -> Error en crear bústia. Compte: %s, Correu: %s, Error: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
+msgstr "Desar correu -> Error en escriure a la bústia. Compte: %s, Correu: %s"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Save in Drafts"
+msgstr "Desa a esborranys"
+
+#. module: poweremail
+#: field:poweremail.preview,save_to_drafts_prev:0
+#: field:poweremail.templates,save_to_drafts:0
+msgid "Save to Drafts"
+msgstr "Desa a esborranys"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
+msgstr "Guardant capçalera de càrrega desconeguda (%s). Compte: %s."
+
+#. module: poweremail
+#: field:poweremail.template.attachment,search_params:0
+msgid "Search params"
+msgstr "Paràmetres de recerca"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Select Folder"
+msgstr "Selecciona carpeta"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Select a folder before you save record"
+msgstr "Seleccioneu una carpeta abans de desar el registre"
 
 #. module: poweremail
 #: help:poweremail.core_accounts,company:0
@@ -1088,38 +1902,197 @@ msgid ""
 msgstr "Indica si aquest compte de correu electrònic no pertany a un usuari específic, sinó a l'organització. per exemple: info@domini.com"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:461
+#: help:poweremail.templates,model_object_field:0
+msgid ""
+"Select the field from the model you want to use.\n"
+"If it is a relationship field you will be able to choose the nested values in the box below.\n"
+"(Note: If there are no values make sure you have selected the correct model)."
+msgstr "Seleccioneu el camp del model que voleu utilitzar.\nSi és un camp de relació podreu triar els valors relacionats en l'opció inferior.\n(Nota: Si no hi han valors assegureu-vos de seleccionar el model correcte)."
+
+#. module: poweremail
+#: help:poweremail.templates,table_model_object_field:0
+msgid ""
+"Select the field from the model you want to use.\n"
+"Only one2many & many2many fields can be used for tables."
+msgstr "Seleccioneu el camp del model que voleu utilitzar.\nNomés els camps one2many i many2many es poden utilitzar per a les taules."
+
+#. module: poweremail
+#: help:poweremail.templates,table_required_fields:0
+msgid "Select the fields you require in the table."
+msgstr "Seleccioneu els camps que necessiteu a la taula."
+
+#. module: poweremail
+#: help:poweremail.templates,auto_email:0
+msgid ""
+"Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
+"Note: Auto email can be enabled only after saving template."
+msgstr "Si seleccioneu correu electrònic automàtic es crearà una acció de servidor perquè s'enviï el correu després de crear-se/actualitzar-se un registre.\nAtenció: Es pot activar el correu automàtic només desprès de desar la plantilla."
+
+#. module: poweremail
+#: field:poweremail.templates,send_count:0
+msgid "Send Count"
+msgstr "Nombre d'enviaments"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Send Email"
+msgstr "Envia el correu"
+
+#. module: poweremail
+#: field:poweremail.templates,send_immediately:0
+msgid "Send Immediately"
+msgstr "Enviar immediatament"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Send Mail"
+msgstr "Envia correu"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "Mail from Account %s failed. Probable Reason: Account not approved"
-msgstr "Correu des del compte %s ha fallat. Motiu probable: Compte no aprovat."
+msgid "Send Mail (%s)"
+msgstr "Envia correu (%s)"
 
 #. module: poweremail
-#: field:poweremail.templates,model_data_name:0
-msgid "Code"
-msgstr "Codi"
+#: selection:poweremail.send.wizard,state:0
+msgid "Send Type"
+msgstr "Tipus d'enviament"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:710
+#: view:poweremail.send.wizard:0
+msgid "Send all mails"
+msgstr "Envia tots els correus"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send mail Wizard"
+msgstr "Assistent d’enviament de correu"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send now"
+msgstr "Envia ara"
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_create:0
+msgid "Send on Create"
+msgstr "Envia al crear"
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_write:0
+msgid "Send on Update"
+msgstr "Envia a l'actualitzar"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Send/Receive"
+msgstr "Envia/Rebre"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
+#: selection:poweremail.mailbox,state:0
+msgid "Sending"
+msgstr "Enviant"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
 msgid ""
-"Datetime Extraction failed. Date: %s\n"
+"Sending mail from Account {} failed.\n"
+"Description: {}"
+msgstr "Enviament fallit de correus desde el compte {}.\nDescripció: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid ""
+"Sending of Mail %s failed. Probable Reason: Could not login to server\n"
 "Error: %s"
-msgstr "Ha fallat l'extracció de Data-Hora. Data: %s\nError: %s"
+msgstr "L'enviament del correu %s ha fallat. Motiu probable: No s'ha autenticat amb el servidor.\nError: %s"
 
 #. module: poweremail
-#: field:poweremail.templates,record_attachment_categories:0
-msgid "Record attachment categories"
-msgstr "Categories dels adjunts dels registres"
+#: help:poweremail.templates,send_on_write:0
+msgid "Sends an e-mail when a document is modified."
+msgstr "Envia un correu electrònic quan es modifica un document."
 
 #. module: poweremail
-#: field:poweremail.templates,auto_email:0
-msgid "Auto Email"
-msgstr "Correu electrònic automàtic"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
+msgid "Sent"
+msgstr "Enviats"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,smtpport:0
-msgid "SMTP Port "
-msgstr "Port SMTP"
+#: field:poweremail.core_accounts,smtpserver:0
+msgid "Server"
+msgstr "Servidor"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Server Information"
+msgstr "Informació del servidor"
+
+#. module: poweremail
+#: field:poweremail.mailbox,server_ref:0
+msgid "Server Reference of mail"
+msgstr "Referència del servidor de correu"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,iserver_type:0
+msgid "Server Type"
+msgstr "Tipus de servidor"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
+msgid "Shows a list of IMAP folders"
+msgstr "Mostra la llista de les carpetes IMAP"
+
+#. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid ""
+"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
+"els adjunts del registre utilitzat per renderitzar el email."
+msgstr "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+
+#. module: poweremail
+#: selection:poweremail.send.wizard,state:0
+msgid "Simple Mail Wizard Step 1"
+msgstr "Assistent correu simple - Pas 1"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,single_email:0
+#: field:poweremail.templates,single_email:0
+msgid "Single email"
+msgstr "Només un correu electrònic"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_text:0
+#: field:poweremail.templates,def_body_text:0
+msgid "Standard Body (Text)"
+msgstr "Cos del missatge (Text)"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpssl:0
+msgid "Start a SMTP connection through SSL (Usually port 465)"
+msgstr "Establir una connexió SMTP utilitzant SSL (normalment port 465)"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtptls:0
+msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
+msgstr "Establir una connexió TLS després de la connexió SMTP (normalment port 587)"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Full mail reception for mail: %s."
+msgstr "Iniciant recepció complerta de correus pel correu: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Header reception for account: %s."
+msgstr "Iniciant recepció de capçalera pel compte: %s."
 
 #. module: poweremail
 #: field:poweremail.preview,state:0 field:wizard.change.folder.email,state:0
@@ -1128,274 +2101,59 @@ msgid "State"
 msgstr "Estat"
 
 #. module: poweremail
-#: help:poweremail.templates,copyvalue:0
-msgid ""
-"Copy and paste the value in the location you want to use a system value."
-msgstr "Copieu i enganxeu el valor en la ubicació que voleu utilitzar un valor del sistema."
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Plain Text"
-msgstr "Text pla"
-
-#. module: poweremail
-#: field:poweremail.templates,ref_ir_value:0
-msgid "Wizard Button"
-msgstr "Botó assistent"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "Mail fetch exception"
-msgstr "Excepció d'extracció de correu"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
-msgstr "Introduïu el port, per exemple per SMTP 587."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1376
-#, python-format
-msgid "%s Mail Form"
-msgstr "%s formulari de correu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1050
-#, python-format
-msgid "Starting Full mail reception for mail: %s."
-msgstr "Iniciant recepció complerta de correus pel correu: %s."
-
-#. module: poweremail
-#: view:poweremail.preview:0 field:poweremail.preview,env:0
-msgid "Extra scope variables"
-msgstr "Variables extres de l'àmbit (scope)"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#, python-format
-msgid ""
-"No personal email accounts are configured for you. \n"
-"Either ask admin to enforce an account for this template or get yourself a personal power email account."
-msgstr "No s'us han configurat comptes de correu personals.\nSol·liciteu a l'administrador que us proporcioni un compte per aquesta plantilla o obtingueu un compte de correu personal de poweremail."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1078
-#, python-format
-msgid "IMAP Folder selected successfully Account: %s."
-msgstr "Carpeta IMAP seleccionada correctament. Compte: %s."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
-msgid "Emails to sent"
-msgstr "Correus per enviar"
+#: view:poweremail.templates:0
+msgid "Static attachments"
+msgstr "Adjunts estàtics"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "o - current object"
-msgstr "o - objecte actual"
+msgid "Stats"
+msgstr "Estadístiques"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,isfolder:0 field:poweremail.mailbox,folder:0
-#: field:wizard.change.folder.email,folder:0
-msgid "Folder"
-msgstr "Carpeta"
+#: field:poweremail.templates,stats_interval:0
+msgid "Stats Interval"
+msgstr "Interval d'estadístiques"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
-msgid "Trash"
-msgstr "Paperera"
+#: field:poweremail.mailbox,state:0 field:poweremail.send.wizard,state:0
+msgid "Status"
+msgstr "Estat"
 
 #. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar correos relacionados"
-msgstr "Buscar correus relacionats"
+#: field:poweremail.templates,sub_model_object_field:0
+msgid "Sub Field"
+msgstr "Sub-camp"
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Attachment settings"
-msgstr "Configuració de l'adjunt"
+#: field:poweremail.templates,sub_object:0
+msgid "Sub-model"
+msgstr "Sub-model"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1267
-#: code:addons/poweremail/poweremail_core.py:1270
-#, python-format
-msgid "IMAP Server Folder Error"
-msgstr "Error carpeta servidor IMAP"
+#: field:poweremail.preview,subject:0 field:poweremail.send.wizard,subject:0
+msgid "Subject"
+msgstr "Subjecte"
 
 #. module: poweremail
-#: field:poweremail.templates,partner_event:0
-msgid "Partner ID to log Events"
-msgstr "ID empresa per a registrar esdeveniments"
+#: view:poweremail.core_accounts:0
+msgid "Suspend Account"
+msgstr "Suspendre compte"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:405
-#, python-format
-msgid "Incoming server password is not defined"
-msgstr "No s'ha definit la contrasenya del servidor d'entrada"
+#: selection:poweremail.core_accounts,state:0
+msgid "Suspended"
+msgstr "Suspès"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:399
-#, python-format
-msgid "Incoming server is not defined"
-msgstr "No s'ha definit el servidor d'entrada"
+#: field:poweremail.templates,table_model_object_field:0
+msgid "Table Field"
+msgstr "Camp de la taula"
 
 #. module: poweremail
-#: field:poweremail.templates,null_value:0
-msgid "Null Value"
-msgstr "Valor nul"
-
-#. module: poweremail
-#: field:poweremail.templates,template_language:0
-msgid "Templating Language"
-msgstr "Templating Language"
-
-#. module: poweremail
-#: field:poweremail.conversation,name:0
-msgid "Name"
-msgstr "Nom"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Trash"
-msgstr "Paperera"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
-msgid "Personal Accounts"
-msgstr "Comptes personals"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Sent"
-msgstr "Enviat"
-
-#. module: poweremail
-#: help:poweremail.templates,table_html:0
-msgid ""
-"Copy this html code to your HTML message body for displaying the info in "
-"your mail."
-msgstr "Copieu aquest codi HTML en el cos del missatge HTML per a mostrar la informació al vostre correu electrònic."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:296
-#, python-format
-msgid "Core connection for the given ID does not exist"
-msgstr "La connexió bàsica per l'ID donat no existeix"
-
-#. module: poweremail
-#: help:poweremail.templates,server_action:0
-msgid "Corresponding server action is here."
-msgstr "L'acció de servidor corresponent està aquí."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "cr - database cursor"
-msgstr "cr - cursor BBDD"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
-#: view:wizard.send.email:0
-msgid "Enviar emails"
-msgstr "Enviar emails"
-
-#. module: poweremail
-#: view:poweremail.templates:0 field:poweremail.templates,filter:0
-msgid "Filter"
-msgstr "Filtre"
-
-#. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
-msgid "Reenviar emails amb error"
-msgstr "Reenviar correus amb error"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1154
-#, python-format
-msgid ""
-"Incoming server login attempt dropped Account: %s\n"
-"Check if Incoming server attributes are complete."
-msgstr "Intent d'autenticació amb el servidor d'entrada avortat. Compte: %s.\nComproveu si les dades del servidor d'entrada estan complertes."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_template_emails
-msgid "Template emails"
-msgstr "Plantilles de correu"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
-msgid "IMAP Folder Selection Wizard"
-msgstr "Assistent selecció carpeta IMAP"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "High"
-msgstr "Alta"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1072
-#, python-format
-msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
-msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:224
-#, python-format
-msgid "The email must have a sending account."
-msgstr "El correu ha de tenir un compte d'enviament."
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Simple Mail Wizard Step 1"
-msgstr "Assistent correu simple - Pas 1"
-
-#. module: poweremail
-#: field:poweremail.templates,attach_record_items:0
-msgid "Attach record items"
-msgstr "Adjuntar elements"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:62
-#, python-format
-msgid "Error receiving mail: %s"
-msgstr "Error rebent correu: %s"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Create send email wizard"
-msgstr "Crear assistent d'enviament de correu"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send mail Wizard"
-msgstr "Assistent envia correu"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Power Email Templates"
-msgstr "Plantilles de correu electrònic"
-
-#. module: poweremail
-#: view:wizard.change.folder.email:0
-msgid "Emails canviats de carpeta!"
-msgstr "Emails canviats de safata!"
-
-#. module: poweremail
-#: help:poweremail.templates,record_attachment_categories:0
-msgid ""
-"Only attach record attachments with the included categories in case there's "
-"any."
-msgstr "Adjuntar únicament els adjunts del registre amb les categories incloses si és que n'hi ha alguna."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:311
-#, python-format
-msgid "Error sending email with id {}: {}"
-msgstr "Error enviat el correu amb id {}: {}"
+#: field:poweremail.templates,table_sub_object:0
+msgid "Table-model"
+msgstr "Model-Taula"
 
 #. module: poweremail
 #: field:ir.actions.server,poweremail_template:0
@@ -1406,304 +2164,91 @@ msgid "Template"
 msgstr "Plantilla"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,smtpserver:0
-msgid "Enter name of outgoing server, eg: smtp.gmail.com"
-msgstr "Escriviu el nom del servidor de correu de sortida, per exemple: smtp.gmail.com"
+#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
+msgid "Template Preview"
+msgstr "Vista prèvia de la plantilla"
 
 #. module: poweremail
-#: view:poweremail.preview:0
-msgid "Power Email Preview"
-msgstr "Previsualització"
+#: model:ir.actions.act_window,name:poweremail.action_template_emails
+msgid "Template emails"
+msgstr "Plantilles de correu"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:990
-#, python-format
-msgid "Error evaluating the expression in 'Reference of the report' field: %s"
-msgstr "Error en avaluar l'expressió del camp 'Referència de l'informe': %s"
+#: field:poweremail.preview,model_ref:0
+msgid "Template reference"
+msgstr "Plantilla"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:532
-#, python-format
-msgid "Email will be sent again"
-msgstr "El correu es tornarà a enviar"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
+msgid "Templates"
+msgstr "Plantilles"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
-msgstr "Correu original"
+#: field:poweremail.templates,template_language:0
+msgid "Templating Language"
+msgstr "Templating Language"
 
 #. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body HTML"
-msgstr "Cos HTML"
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Text otherwise HTML"
+msgstr "Text, en cas contrari HTML"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,iserver:0
-msgid "Enter name of incoming server, eg: imap.gmail.com"
-msgstr "Introduïu el nom del servidor de correu d'entrada, per exemple: imap.gmail.com"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1314
-#, python-format
-msgid "This is an invalid folder"
-msgstr "Aquesta carpeta no és vàlida"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
+#: constraint:ir.model:0
 msgid ""
-"Check it if you want to send a single email for several records (the "
-"optional attachment will be generated as a single file for all these r "
-"ecords). If you don't check it, an email with its optional attachment will "
-"be send for each record."
-msgstr "Seleccioneu-lo si voleu enviar un únic correu electrònic per als diversos registres (l'adjunt opcional es genera com un únic arxiu per a tots aquests registres). Si no el seleccioneu, s'envia un correu electrònic amb el seu adjunt opcional per a cada registre."
+"The Object name must start with x_ and not contain any special character !"
+msgstr "El nom de l'objecte ha de començar amb x_ i no contenir cap caràcter especial!"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,email_id:0
-msgid "eg: yourname@yourdomain.com"
-msgstr "Exemple: elvostrenom@elvostredomini.com"
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "The body of the email must not be empty."
+msgstr "El contingut de l'email no pot estar buit."
 
 #. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
+#: help:poweremail.templates,def_bcc:0
+msgid "The default BCC for the email. Placeholders can be used here."
+msgstr "El BCC per defecte del correu electrònic. Es poden usar expressions de camps."
+
+#. module: poweremail
+#: help:poweremail.templates,def_cc:0
+msgid "The default CC for the email. Placeholders can be used here."
+msgstr "El CC per defecte del correu electrònic. Es poden usar expressions de camps."
+
+#. module: poweremail
+#: help:poweremail.templates,lang:0
 msgid ""
-"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
-"els adjunts del registre utilitzat per renderitzar el email."
-msgstr "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+"The default language for the email. Placeholders can be used here. eg. "
+"${object.partner_id.lang}"
+msgstr "L'idioma per defecte del correu electrònic. Es poden usar expressions de camps, per ex. ${object.partner_id.lang}"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
-msgid "Mailbox: Sending"
-msgstr "Bústia: Enviant"
+#: help:poweremail.templates,def_to:0
+msgid "The default recepient of email. Placeholders can be used here."
+msgstr "El destinatari per defecte del correu electrònic. Es poden usar expressions de camps."
 
 #. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
-msgid "Demo email subject for user ${object.login}"
-msgstr "Assumpte de correu de demostració per a l'usuari ${object.login}"
+#: help:poweremail.templates,def_subject:0
+msgid "The default subject of email. Placeholders can be used here."
+msgstr "El subjecte per defecte del correu electrònic. Es poden usar expressions de camps."
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email All Emails"
-msgstr "Tots els correus"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
-msgstr "No descarrega els adjunts automàticament"
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,folder:0
-msgid "IMAP Folder"
-msgstr "Carpeta IMAP"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Automatisms settings"
-msgstr "Configuració de l'automatització"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isssl:0
-#: field:poweremail.core_accounts,smtpssl:0
-msgid "Use SSL"
-msgstr "Utilitza SSL"
-
-#. module: poweremail
-#: model:poweremail.templates,file_name:poweremail.default_template_poweremail_2
-msgid "${object.number}"
-msgstr "${object.number}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:456
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
 #, python-format
-msgid ""
-"Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
-"Error: %s"
-msgstr "Correu des del compte %s ha fallat a l'autenticació. Motiu probable: No es pot autenticar amb el servidor.\nError: %s"
+msgid "The email address is not valid."
+msgstr "L’adreça de correu no és vàlida."
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Insert Simple Field"
-msgstr "Insereix camp simple"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
-msgid "Mailbox: Sent"
-msgstr "Safata: Enviats"
-
-#. module: poweremail
-#: field:poweremail.mailbox,priority:0 field:poweremail.send.wizard,priority:0
-msgid "Priority"
-msgstr "Prioritat"
-
-#. module: poweremail
-#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail
-msgid ""
-"<!doctype html>\n"
-"<html>\n"
-"<head></head>\n"
-"<body>\n"
-"This is a demo email\n"
-"</body>\n"
-"</html>"
-msgstr "<!doctype html>\n<html>\n<head></head>\n<body>\nAquest és un correu de demostració\n</body>\n</html>"
-
-#. module: poweremail
-#: help:poweremail.templates,send_on_create:0
-msgid ""
-"Create an e-mail when a new record is created. The instance where the record"
-" is created must be restarted for the changes to take effect."
-msgstr "Crear un correu electrònic quan es creï un registre nou. La instància on es crea el registre s’ha de reiniciar perquè els canvis tinguin efecte."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
-msgid "Email Basic Templates"
-msgstr "Plantilles de correu bàsiques"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:315
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "Out going connection test failed"
-msgstr "El test de la connexió de sortida ha fallat"
+msgid "The email must have a destiny account."
+msgstr "El correu ha de tenir un compte de destí."
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
-msgid "Sent"
-msgstr "Enviats"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:416
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "The specified record for connection does not exist"
-msgstr "Envia un correu electrònic quan es crea un document nou."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#, python-format
-msgid "Please specify an template to use for auto email in poweremail!"
-msgstr "Indiqueu una plantilla per usar pels correus automàtics a poweremail!"
-
-#. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Mako Templates"
-msgstr "Plantilles Mako"
-
-#. module: poweremail
-#: field:poweremail.templates,def_priority:0
-msgid "Default priority"
-msgstr "Prioritat per defecte"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_send_email
-msgid "wizard.send.email"
-msgstr "wizard.send.email"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtptls:0
-msgid "Use TLS"
-msgstr "Utilitza TLS"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
-msgid "Mailbox: All emails"
-msgstr "Bústia: Tots els correus"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 view:poweremail.templates:0
-msgid "Advanced"
-msgstr "Avançat"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
-#: selection:poweremail.mailbox,state:0
-msgid "Sending"
-msgstr "Enviant"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:959
-#, python-format
-msgid ""
-"IMAP Server Folder Selection Error Account: %s Error: %s.\n"
-"Check account settings if you have selected a folder."
-msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s.\nComproveu si heu seleccionat una carpeta a la configuració del compte."
-
-#. module: poweremail
-#: field:poweremail.core_accounts,state:0
-msgid "Account Status"
-msgstr "Estat del compte"
-
-#. module: poweremail
-#: help:poweremail.preview,enforce_from_account:0
-msgid "Email will be sent from this account."
-msgstr "El correu s'enviarà des d'aquest compte."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1123
-#, python-format
-msgid "POP3 Server Error Account: %s Error: %s."
-msgstr "Error del servidor POP3 al compte %s. Error: %s."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Select Folder"
-msgstr "Selecciona carpeta"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:245
-#, python-format
-msgid "Email sent successfully"
-msgstr "Email enviat correctament"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtpserver:0
-msgid "Server"
-msgstr "Servidor"
-
-#. module: poweremail
-#: help:poweremail.templates,send_immediately:0
-msgid ""
-"Emails created from this template will be sent immediately without going "
-"through outbox folder."
-msgstr "Els correus creats a partir d'aquesta plantilla s'enviaran immediatament sense passar per la carpeta de sortida."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:1061
-#, python-format
-msgid "IMAP Server Connected & logged in successfully Account: %s."
-msgstr "Servidor IMAP connectat i autenticat correctament. Compte: %s."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1140
-#, python-format
-msgid "POP3 Server Connected & logged in successfully Account: %s."
-msgstr "Servidor POP3 connectat i autenticat correctament. Compte: %s."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Other settings"
-msgstr "Altres configuracions"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_subject:0
-msgid " Subject"
-msgstr "Assumpte"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Mail Details"
-msgstr "Detalls del correu electrònic"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:295
-#, python-format
-msgid "SMTP SERVER or PORT not specified"
-msgstr "SERVIDOR SMTP o PORT no especificat"
+msgid "The email must have a sending account."
+msgstr "El correu ha de tenir un compte d'enviament."
 
 #. module: poweremail
 #: view:poweremail.templates:0
@@ -1713,187 +2258,105 @@ msgid ""
 msgstr "El nom de l'arxiu ha de seguir el format: TEXT.IDIOMA.EXTENSIÓ (per exemple: reunió_extraordinaria.ca_ES.pdf) per a identificar el document per idioma."
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Power Email Configuration"
-msgstr "Configuració"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "Yes"
-msgstr "Sí"
-
-#. module: poweremail
-#: field:poweremail.templates,send_immediately:0
-msgid "Send Immediately"
-msgstr "Enviar immediatament"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:396
-#, python-format
-msgid "From Poweremail Mailbox {} Original email as {}"
-msgstr "Desde Safata {} Correu original com {}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:652
-#, python-format
+#: help:poweremail.templates,filter:0
 msgid ""
-"Sending mail from Account {} failed.\n"
-"Description: {}"
-msgstr "Enviament fallit de correus desde el compte {}.\nDescripció: {}"
+"The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
+"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
+msgstr "El codi python introduït ací serà executat. Si el resultat és True el correu serà enviat, si és False no serà enviat.\nExemple : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:930
+#: help:poweremail.templates,use_sign:0
+msgid "The signature from the User details will be appened to the mail."
+msgstr "La signatura de l'usuari (definida a les seves preferències) s'afegirà al correu."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Downloaded & saved %s attachments Account: %s."
-msgstr "Descarregats i desats %s adjunts. Compte: %s."
+msgid "The specified record for connection does not exist"
+msgstr "Envia un correu electrònic quan es crea un document nou."
 
 #. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Low"
-msgstr "Baixa"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
-msgid "My Account"
-msgstr "El meu compte"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Request Re-activation"
-msgstr "Sol.licita reactivació"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1134
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "POP3 Server Login Error Account: %s Error: %s."
-msgstr "Error d'autenticació servidor POP3. Compte: %s Error: %s."
+msgid "The template name must be unique!"
+msgstr "El nom de la plantilla ha de ser únic!"
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Initiated"
-msgstr "Iniciat"
+#: help:poweremail.templates,def_body_html:0
+#: help:poweremail.templates,def_body_text:0
+msgid "The text version of the mail."
+msgstr "La versió text del correu."
+
+#. module: poweremail
+#: help:poweremail.templates,null_value:0
+msgid "This Value is used if the field is empty."
+msgstr "Aquest valor s'utilitza si el camp es troba buit."
+
+#. module: poweremail
+#: help:poweremail.templates,table_sub_object:0
+msgid "This field shows the model you will be using for your table."
+msgstr "Aquest camp mostra el model que s'utilitzarà en la vostra taula."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "This is an invalid folder"
+msgstr "Aquesta carpeta no és vàlida"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_send_wizard
+msgid "This is the wizard for sending mail"
+msgstr "Aquest és l'assistent per enviar el correu electrònic"
+
+#. module: poweremail
+#: help:poweremail.templates,use_filter:0
+msgid ""
+"This option allow you to add a custom python filter before sending a mail"
+msgstr "This option allow you to add a custom python filter before sending a mail"
 
 #. module: poweremail
 #: view:poweremail.send.wizard:0
 msgid ""
 "Tip: Multiple emails are sent in the same language (the first one is "
 "proposed). We suggest you send emails in groups according to langu age."
-msgstr "Consell: Els correus electrònics múltiples s'envien en el mateix idioma (es proposa el primer d'ells). Us suggerim que envieu els correus en grups segons l'idioma."
+msgstr "Consell: Els correus electrònics múltiples s’envien en el mateix idioma (es proposa el primer). Us recomanem que envieu els correus en grups segons l’idioma."
 
 #. module: poweremail
-#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Cancel·lar"
-msgstr "Cancel·lar"
+#: field:poweremail.preview,to:0 field:poweremail.send.wizard,to:0
+msgid "To"
+msgstr "Per"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
-msgid "Outbox"
-msgstr "Sortida"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
+msgid "Trash"
+msgstr "Paperera"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_message_id:0
-msgid "Message-Id"
-msgstr "Message-Id"
+#: selection:poweremail.mailbox,state:0
+msgid "Un-Read"
+msgstr "Sense llegir"
 
 #. module: poweremail
-#: field:poweremail.preview,model_ref:0
-msgid "Template reference"
-msgstr "Plantilla"
+#: field:poweremail.core_accounts,isssl:0
+#: field:poweremail.core_accounts,smtpssl:0
+msgid "Use SSL"
+msgstr "Utilitza SSL"
 
 #. module: poweremail
-#: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
-msgid "CC"
-msgstr "CC"
+#: field:poweremail.templates,use_sign:0
+msgid "Use Signature"
+msgstr "Utilitza la signatura"
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Send Mail"
-msgstr "Envia correu"
+#: field:poweremail.core_accounts,smtptls:0
+msgid "Use TLS"
+msgstr "Utilitza TLS"
 
 #. module: poweremail
-#: field:poweremail.templates,report_template_object_reference:0
-msgid "Reference of the report"
-msgstr "Referència de l'informe"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_change_folder_email_form
-#: view:wizard.change.folder.email:0
-msgid "Canviar emails de carpeta"
-msgstr "Canviar emails de safata"
-
-#. module: poweremail
-#: view:ir.actions.server:0
-msgid "Email Configuration"
-msgstr "Configuració correu electrònic"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:242
-#, python-format
-msgid "An error occurred while rendering template id {}:  {}"
-msgstr "Un error ha passat mentre es renderitzava la plantilla amb id {}:  {}"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
-msgid "Mailbox: Error"
-msgstr "Safata: Error"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,pem_attachments_ids:0
-#: view:poweremail.send.wizard:0 field:poweremail.send.wizard,attachment_ids:0
-#: view:poweremail.template.attachment:0
-#: field:poweremail.templates,ir_attachment_ids:0
-#: field:poweremail.templates,tmpl_attachment_ids:0
-msgid "Attachments"
-msgstr "Adjunts"
-
-#. module: poweremail
-#: field:poweremail.templates,model_object_field:0
-msgid "Field"
-msgstr "Camp"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:753
-#, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
-msgstr "Guardant capçalera de càrrega desconeguda (%s). Compte: %s."
-
-#. module: poweremail
-#: help:poweremail.templates,enforce_from_account:0
-msgid "Emails will be sent only from this account."
-msgstr "Els correus electrònics s'enviaran només des d'aquest compte."
-
-#. module: poweremail
-#: constraint:ir.model:0
-msgid ""
-"The Object name must start with x_ and not contain any special character !"
-msgstr "El nom de l'objecte ha de començar amb x_ i no contenir cap caràcter especial!"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid ""
-"After clicking send all mails, mails will be sent to outbox and cleared in "
-"next Send/Recieve"
-msgstr "Després de fer clic a Envia ara, els correus es posaran a la safata de sortida. El correus s'enviaran en el proper Envia/Rebre (manual o automàtic) de la vostra safata de sortida."
-
-#. module: poweremail
-#: field:poweremail.core_accounts,allowed_groups:0 view:poweremail.templates:0
-#: field:poweremail.templates,allowed_groups:0
-msgid "Allowed User Groups"
-msgstr "Grups d'usuaris permesos"
-
-#. module: poweremail
-#: selection:poweremail.preview,state:0
-#: selection:wizard.change.folder.email,state:0
-#: selection:wizard.change.state.email,wiz_state:0
-#: selection:wizard.send.email,state:0
-msgid "Init"
-msgstr "Init"
+#: field:poweremail.mailbox,pem_user:0
+msgid "User"
+msgstr "Usuari"
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
@@ -1901,21 +2364,28 @@ msgid "User Information"
 msgstr "Informació de l'usuari"
 
 #. module: poweremail
-#: view:wizard.send.email:0
-msgid "Emails enviats!"
-msgstr "Emails enviats!"
+#: field:poweremail.core_accounts,isuser:0
+#: field:poweremail.core_accounts,smtpuname:0
+msgid "User Name"
+msgstr "Nom d'usuari"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:214
+#: field:poweremail.mailbox,pem_account_id:0
+msgid "User account"
+msgstr "Compte d'usuari"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "The body of the email must not be empty."
-msgstr "El contingut de l'email no pot estar buit."
+msgid "Warning"
+msgstr "Avís"
 
 #. module: poweremail
-#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Endavant"
-msgstr "Endavant"
+#: help:poweremail.templates,sub_object:0
+msgid ""
+"When a relation field is used this field will show you the type of field you"
+" have selected."
+msgstr "Quan s'utilitza un camp de relació, aquest camp mostrarà el tipus de camp que heu seleccionat."
 
 #. module: poweremail
 #: help:poweremail.preview,save_to_drafts_prev:0
@@ -1926,346 +2396,6 @@ msgid ""
 msgstr "Quan s'envien correus electrònics generats automàticament a partir d'aquesta plantilla, es desen a la carpeta Esborranys en comptes d'enviar-los immediatament."
 
 #. module: poweremail
-#: help:poweremail.templates,partner_event:0
-msgid ""
-"Partner ID who an email event is logged.\n"
-"Placeholders can be used here. eg. ${object.partner_id.id}\n"
-"You must install the mail_gateway module to see the mail events in partner form.\n"
-"If you also want to record the link to the object that sends the email, you must to add this object in the 'Administration/Low Level Objects/Requests/Accepted Links in Requests' menu (or 'ir.attachment' to record the attachments)."
-msgstr "ID d'empresa a on s'ha de registrar un esdeveniment de correu.\nEs pot usar expressions de camps. Per ex. ${object.partner_id.id}\nHeu d'instal·lar el mòdul mail_gateway per veure els esdeveniments de correu en el formulari d'empresa.\nSi també voleu desar l'enllaç cap a l'objecte que envia el correu, heu d'afegir aquest objecte des del menú 'Administració/Personalització/Objectes de baix nivell/Sol·licituds/Tipus de referències en sol·licituds' (o 'ir.attachment' per desar els adjunts)."
-
-#. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:183
-#, python-format
-msgid "Generated Email"
-msgstr "Correu generat"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Expression builder"
-msgstr "Generador d'expressions"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_accounts
-msgid "poweremail.core_accounts"
-msgstr "poweremail.comptes_bàsics"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Text otherwise HTML"
-msgstr "Text, en cas contrari HTML"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0 view:poweremail.templates:0
-msgid "Body (HTML)"
-msgstr "Cos del missatge (HTML)"
-
-#. module: poweremail
-#: field:poweremail.templates,attached_activity:0
-msgid "Activity"
-msgstr "Activitat"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Remove send email wizard"
-msgstr "Eliminar assistent d'enviament de correu"
-
-#. module: poweremail
-#: view:wizard.change.state.email:0
-msgid "Emails canviats d'estat!"
-msgstr "Emails canviats d'estat!"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:901
-#, python-format
-msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
-msgstr "Desar correu -> Error en escriure a la bústia. Compte: %s, Correu: %s"
-
-#. module: poweremail
-#: field:poweremail.templates,enforce_from_account:0
-msgid "Enforce From Account"
-msgstr "Força des del compte"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Dynamic attachments (reports)"
-msgstr "Adjunts dinàmics (informes)"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,send_pref:0
-msgid "Mail Format"
-msgstr "Format del correu electrònic"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "uid - current user ID"
-msgstr "uid - ID usuari actual"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isport:0
-msgid "Port"
-msgstr "Port"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#, python-format
-msgid "Emails for multiple items saved in outbox."
-msgstr "Correus per a múltiples elements guardats a la bústia de sortida."
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_create:0
-msgid "Send on Create"
-msgstr "Envia al crear"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Plain Text & HTML with no attachments"
-msgstr "Text pla i HTML sense adjunts"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
-#, python-format
-msgid "Deletion of Record failed"
-msgstr "L'eliminació del registre ha fallat"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:342
-#, python-format
-msgid "IMAP Server Error: {}"
-msgstr "Error del servidor IMAP: {}"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
-msgid "Company"
-msgstr "Companyia"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:767
-#: code:addons/poweremail/poweremail_core.py:838
-#, python-format
-msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
-msgstr "Desa capçalera -> Error en crear bústia. Compte: %s, Correu: %s, Error: %s"
-
-#. module: poweremail
-#: field:poweremail.mailbox,create_date:0
-msgid "Created date"
-msgstr "Data de creació"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Approved"
-msgstr "Aprovat"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:219
-#, python-format
-msgid "The email must have a destiny account."
-msgstr "El correu ha de tenir un compte de destí."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:373
-#, python-format
-msgid ""
-"Programming Error in _get_pop3_server method. The record received is "
-"invalid."
-msgstr "Error de programació en el mètode _get_pop3_server. El registre que s'ha rebut no és vàlid."
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Ok"
-msgstr "D'acord"
-
-#. module: poweremail
-#: field:poweremail.template.attachment,file_name:0
-msgid "File name"
-msgstr "Nom del fitxer"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_recd:0
-msgid "Received at"
-msgstr "Rebut el"
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,name:0
-msgid "Email Account"
-msgstr "Compte de correu electrònic"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1011
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s"
-msgstr "Estadístiques POP3: %s correus de grandària %s pel compte: %s"
-
-#. module: poweremail
-#: field:poweremail.preview,bcc:0 field:poweremail.send.wizard,bcc:0
-msgid "BCC"
-msgstr "BCC"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,email_id:0
-msgid "Email ID"
-msgstr "ID correu electrònic"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,full_success:0
-msgid "Complete Success"
-msgstr "El procés s'ha realitzat correctament"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "OK"
-msgstr "D'acord"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_change_folder_email
-msgid "wizard.change.folder.email"
-msgstr "wizard.change.folder.email"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Download Full Mail"
-msgstr "Descarrega tot el correu"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Both HTML & Text"
-msgstr "A la vegada HTML i Text"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
-#, python-format
-msgid "Warning"
-msgstr "Avís"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
-msgid "Follow-up"
-msgstr "Seguiment"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "security"
-msgstr "seguretat"
-
-#. module: poweremail
-#: field:poweremail.templates,ref_ir_act_window:0
-msgid "Window Action"
-msgstr "Acció finestra"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Wizard send email"
-msgstr "Assistent d'enviament de correu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "No information on which mail should be fetched fully"
-msgstr "No existeix informació sobre quin correu hauria de ser extret completament"
-
-#. module: poweremail
-#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
-msgid ""
-"\n"
-"\n"
-"<!doctype html>\n"
-"<html>\n"
-"<head></head>\n"
-"<body>\n"
-"Benvolgut/da ${object.login},\n"
-"\n"
-"Això és un email generic de prova per les poweremail_camapign.\n"
-"\n"
-"\n"
-"Atentament,\n"
-"\n"
-"un mort de gana.\n"
-"</body>\n"
-"</html>\n"
-"\n"
-"\t\t\t"
-msgstr "\n\n<!doctype html>\n<html>\n<head></head>\n<body>\nBenvolgut/da ${object.login},\n\nAixò és un email generic de prova per les poweremail_camapign.\n\n\nAtentament,\n\nGISCE.\n</body>\n</html>\n\n\t\t\t"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Error"
-msgstr "Error de Power Email"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_body_html:0
-#: field:poweremail.templates,def_body_html:0
-msgid "Body (Text-Web Client Only)"
-msgstr "Cos del missatge (Text - Només client web)"
-
-#. module: poweremail
-#: field:wizard.change.state.email,estat:0
-msgid "Estat"
-msgstr "Estat"
-
-#. module: poweremail
-#: help:poweremail.templates,table_required_fields:0
-msgid "Select the fields you require in the table."
-msgstr "Seleccioneu els camps que necessiteu a la taula."
-
-#. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
-msgstr "Plantilla Django"
-
-#. module: poweremail
-#: help:poweremail.templates,def_priority:0
-msgid "Default priority for auto generated emails"
-msgstr "Prioritat per defecte pels correus generats automàticament"
-
-#. module: poweremail
-#: field:poweremail.templates,use_sign:0
-msgid "Use Signature"
-msgstr "Utilitza la signatura"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_account_id:0
-msgid "User account"
-msgstr "Compte d'usuari"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,signature:0
-msgid "Attach my signature to mail"
-msgstr "Afegeix la meva signatura al correu"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:438
-#, python-format
-msgid "Incoming Test Connection Was Successful"
-msgstr "El test de la connexió d'entrada ha estat un èxit"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
-msgid "Emails sent today"
-msgstr "Correus enviats avui"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
-msgid "Configuration"
-msgstr "Configuració"
-
-#. module: poweremail
-#: constraint:ir.cron:0
-msgid "Invalid arguments"
-msgstr "Invalid arguments"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "HTML Body"
-msgstr "Cos del missatge HTML"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:435
-#, python-format
-msgid "In coming connection test failed"
-msgstr "El test de la connexió d'entrada ha fallat"
-
-#. module: poweremail
 #: help:poweremail.templates,sub_model_object_field:0
 msgid ""
 "When you choose relationship fields this field will specify the sub value "
@@ -2273,162 +2403,89 @@ msgid ""
 msgstr "Quan trieu els camps de relació, aquest camp indicarà el sub-valor que podeu utilitzar."
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Body (Text)"
-msgstr "Cos del missatge (Text)"
+#: field:poweremail.templates,ref_ir_act_window:0
+msgid "Window Action"
+msgstr "Acció finestra"
 
 #. module: poweremail
-#: field:poweremail.template.attachment,report_id:0
-#: field:poweremail.templates,report_template:0
-msgid "Report to send"
-msgstr "Informe per enviar"
+#: field:poweremail.templates,ref_ir_value:0
+msgid "Wizard Button"
+msgstr "Botó assistent"
 
 #. module: poweremail
 #: selection:poweremail.send.wizard,state:0
-msgid "Multiple Mail Wizard Step 1"
-msgstr "Assistent correus múltiples - Pas 1"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "HTML otherwise Text"
-msgstr "HTML, en cas contrari Text"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,user:0
-msgid "Related User"
-msgstr "Usuari relacionat"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "No"
-msgstr "No"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
-msgid "Emails in error folder"
-msgstr "Correus a la carpeta d'errors"
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Preview Email"
-msgstr "Vista prèvia del correu"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_from:0
-msgid "From"
-msgstr "Des de"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:996
-#, python-format
-msgid ""
-"The expression in 'Reference of the report' field returned an empty value or"
-" a value that is not an integer ID."
-msgstr "L'expressió del camp 'Referència de l'informe' ha retornat un valor buit o un valor que no és un ID enter."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Suspend Account"
-msgstr "Suspendre compte"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Normal"
-msgstr "Normal"
+msgid "Wizard Complete"
+msgstr "Assistent complert"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Available global variables:"
-msgstr "Available global variables:"
+msgid "Wizard send email"
+msgstr "Assistent d'enviament de correu"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
-msgid "Email Templates"
-msgstr "Plantilles de correu electrònic"
+#: field:poweremail.templates,attached_wkf:0
+msgid "Workflow"
+msgstr "Flux de treball"
 
 #. module: poweremail
-#: field:poweremail.templates,sub_model_object_field:0
-msgid "Sub Field"
-msgstr "Sub-camp"
+#: selection:poweremail.core_accounts,company:0
+msgid "Yes"
+msgstr "Sí"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_user:0
-msgid "User"
-msgstr "Usuari"
+#: view:poweremail.templates:0
+msgid "context - current context"
+msgstr "context - context actual"
 
 #. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
-msgid "Factura ${object.number}"
-msgstr "Factura ${object.number}"
+#: view:poweremail.templates:0
+msgid "cr - database cursor"
+msgstr "cr - cursor BBDD"
 
 #. module: poweremail
-#: field:poweremail.mailbox,write_date:0
-msgid "Date modified"
-msgstr "Data de modificació"
+#: help:poweremail.core_accounts,email_id:0
+msgid "eg: yourname@yourdomain.com"
+msgstr "Exemple: elvostrenom@elvostredomini.com"
 
 #. module: poweremail
-#: field:poweremail.templates,file_name:0
-msgid "File Name Pattern"
-msgstr "Patró nom de fitxer"
+#: view:poweremail.templates:0
+msgid "o - current object"
+msgstr "o - objecte actual"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1397
-#: code:addons/poweremail/poweremail_template.py:1411
-#, python-format
-msgid "Send Mail (%s)"
-msgstr "Envia correu (%s)"
+#: model:ir.model,name:poweremail.model_poweremail_core_accounts
+msgid "poweremail.core_accounts"
+msgstr "poweremail.comptes_bàsics"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:213
-#: code:addons/poweremail/poweremail_mailbox.py:218
-#: code:addons/poweremail/poweremail_mailbox.py:223
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#: code:addons/poweremail/poweremail_template.py:989
-#: code:addons/poweremail/poweremail_template.py:995
-#: code:addons/poweremail/poweremail_template.py:1017
-#: code:addons/poweremail/poweremail_template.py:1026
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:153
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
-#: selection:poweremail.preview,state:0
-#, python-format
-msgid "Error"
-msgstr "Error"
+#: model:ir.model,name:poweremail.model_poweremail_template_attachment
+msgid "poweremail.template.attachment"
+msgstr "poweremail.template.attachment"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,iserver:0
-msgid "Incoming Server"
-msgstr "Servidor d'entrada"
+#: view:poweremail.core_accounts:0
+msgid "security"
+msgstr "seguretat"
 
 #. module: poweremail
-#: help:poweremail.templates,table_model_object_field:0
-msgid ""
-"Select the field from the model you want to use.\n"
-"Only one2many & many2many fields can be used for tables."
-msgstr "Seleccioneu el camp del model que voleu utilitzar.\nNomés els camps one2many i many2many es poden utilitzar per a les taules."
+#: view:poweremail.templates:0
+msgid "self - objects pointer"
+msgstr "self - punters a objectes"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1027
-#, python-format
-msgid ""
-"No records found evaluating the expression in 'Reference of the report' "
-"field."
-msgstr "No s'han trobat registres en avaluar l'expressió del camp 'Referència de l'informe'."
+#: view:poweremail.templates:0
+msgid "uid - current user ID"
+msgstr "uid - ID usuari actual"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:70
-#, python-format
-msgid "Django templates not installed"
-msgstr "Les plantilles Django no estan instal·lades"
+#: field:poweremail.conversation,from_abstract:0
+msgid "unknown"
+msgstr "desconegut"
 
 #. module: poweremail
-#: view:poweremail.conversation:0
-msgid "Power Email Conversation"
-msgstr "Converses"
+#: model:ir.model,name:poweremail.model_wizard_change_folder_email
+msgid "wizard.change.folder.email"
+msgstr "wizard.change.folder.email"
 
 #. module: poweremail
 #: model:ir.model,name:poweremail.model_wizard_change_state_email
@@ -2436,160 +2493,11 @@ msgid "wizard.change.state.email"
 msgstr "wizard.change.state.email"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_cc:0
-msgid " CC"
-msgstr " CC"
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
+msgstr "wizard.emails.generats.model"
 
 #. module: poweremail
-#: help:poweremail.templates,def_body_html:0
-#: help:poweremail.templates,def_body_text:0
-msgid "The text version of the mail."
-msgstr "La versió text del correu."
-
-#. module: poweremail
-#: help:poweremail.templates,use_sign:0
-msgid "The signature from the User details will be appened to the mail."
-msgstr "La signatura de l'usuari (definida a les seves preferències) s'afegirà al correu."
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Close"
-msgstr "Tanca"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:69
-#, python-format
-msgid "Error sending mail: %s"
-msgstr "Error enviant correu: %s"
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Llistar correus relacionats"
-msgstr "Llistar correus relacionats"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Check Incoming Connection"
-msgstr "Comprova la connexió d'entrada"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
-msgid "Personal"
-msgstr "Personal"
-
-#. module: poweremail
-#: field:poweremail.preview,to:0 field:poweremail.send.wizard,to:0
-msgid "To"
-msgstr "Per"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,isport:0
-msgid "For example IMAP: 993,POP3:995"
-msgstr "Per exemple IMAP: 993, POP3: 995."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
-#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
-msgid "Buscar Correus Relacionats"
-msgstr "Buscar Correus Relacionats"
-
-#. module: poweremail
-#: help:poweremail.templates,def_bcc:0
-msgid "The default BCC for the email. Placeholders can be used here."
-msgstr "El BCC per defecte del correu electrònic. Es poden usar expressions de camps."
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
-msgid "Templates"
-msgstr "Plantilles"
-
-#. module: poweremail
-#: help:poweremail.templates,def_subject:0
-msgid "The default subject of email. Placeholders can be used here."
-msgstr "El subjecte per defecte del correu electrònic. Es poden usar expressions de camps."
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Read"
-msgstr "Llegit"
-
-#. module: poweremail
-#: help:poweremail.templates,inline:0
-msgid "If the option is checked, the CSS will be inlined inside the HTML"
-msgstr "Si es marca l'opció, el CSS s'incrustarà als elements HTML"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,rec_headers_den_mail:0
-msgid "First Receive headers, then download mail"
-msgstr "Primer es descarreguen les capçaleres, després el correu"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Insert Table"
-msgstr "Insereix taula"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,ispass:0
-#: field:poweremail.core_accounts,smtppass:0
-msgid "Password"
-msgstr "Contrasenya"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:946
-#, python-format
-msgid "Starting Header reception for account: %s."
-msgstr "Iniciant recepció de capçalera pel compte: %s."
-
-#. module: poweremail
-#: field:poweremail.preview,report:0
-msgid "Report Name"
-msgstr "Nom informe"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
-msgid "Template Preview"
-msgstr "Previsualització de la plantilla"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
-#: view:wizard.change.state.email:0
-msgid "Canviar estat dels emails"
-msgstr "Canviar estat dels emails"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "OpenObject Code Filter:"
-msgstr "OpenObject Code Filter:"
-
-#. module: poweremail
-#: field:poweremail.templates,def_subject:0
-msgid "Default Subject"
-msgstr "Assumpte per defecte"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
-msgid "Company Accounts"
-msgstr "Comptes de la companyia"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
-msgid "Inbox"
-msgstr "Entrada"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Has Attachments"
-msgstr "Té adjunts"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Inbox"
-msgstr "Entrada"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:958
-#, python-format
-msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
-msgstr "Error selecció carpeta servidor IMAP. Compte: %s Error: %s."
+#: model:ir.model,name:poweremail.model_wizard_send_email
+msgid "wizard.send.email"
+msgstr "wizard.send.email"

--- a/i18n/es_ES.po
+++ b/i18n/es_ES.po
@@ -1,5 +1,3 @@
-# Translation of OpenERP Server.
-# This file contains the translation of the following modules:
 # 
 # Translators:
 #   <>, 2023, 2025, 2026.
@@ -8,218 +6,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GISCE-ERP\n"
 "Report-Msgid-Bugs-To: https://github.com/gisce/erp/issues\n"
-"POT-Creation-Date: 2026-03-20 11:21\n"
-"PO-Revision-Date: 2026-03-20 10:23+0000\n"
+"PO-Revision-Date: 2026-08-24 12:52+0000\n"
 "Last-Translator: destanyol <>\n"
 "Language-Team: Spanish (Spain) <erp@dev.gisce.net>\n"
-"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
 "Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: poweremail
-#: help:poweremail.templates,send_immediately:0
+#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
 msgid ""
-"Emails created from this template will be sent immediately without going "
-"throug outbox folder."
-msgstr "Los correos electrónicos creados a partir de esta plantilla se enviarán inmediatamente sin pasar por la carpeta de salida."
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
-msgid "Shows a list of IMAP folders"
-msgstr "Muestra la lista de carpetas IMAP"
-
-#. module: poweremail
-#: field:poweremail.templates,def_bcc:0
-msgid "Default BCC"
-msgstr "BCC por defecto"
-
-#. module: poweremail
-#: help:poweremail.templates,model_object_field:0
-msgid ""
-"Select the field from the model you want to use.\n"
-"If it is a relationship field you will be able to choose the nested values in the box below.\n"
-"(Note: If there are no values make sure you have selected the correct model)."
-msgstr "Seleccione el campo del modelo que quiera utilizar.\nSi es un campo de relación podrá escoger los valores relacionados en la opción inferior.\n(Nota: Si no hay valores asegúrese de escoger el modelo correcto)."
-
-#. module: poweremail
-#: constraint:ir.actions.act_window:0
-msgid "Invalid model name in the action definition."
-msgstr "Nombre del módulo inválido en la definición de la acción."
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid " "
-msgstr " "
-
-#. module: poweremail
-#: field:poweremail.templates,attached_wkf:0
-msgid "Workflow"
-msgstr "Flujo de trabajo"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,single_email:0
-#: field:poweremail.templates,single_email:0
-msgid "Single email"
-msgstr "Sólo un correo electrónico"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:904
-#, python-format
-msgid "Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr "Correo %s guardado correctamente como ID: %s para cuenta: %s."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
-msgid "Personal Account"
-msgstr "Cuenta personal"
-
-#. module: poweremail
-#: field:poweremail.mailbox,server_ref:0
-msgid "Server Reference of mail"
-msgstr "Referencia del servidor de correo"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
-msgid "My Accounts"
-msgstr "Mis cuentas"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Incoming"
-msgstr "Entrada"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#, python-format
-msgid ""
-"Sending of Mail %s failed. Probable Reason: Could not login to server\n"
-"Error: %s"
-msgstr "El envío del correo %s ha fallado. Probable razón: No se pudo conectar con el servidor\nError: %s"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Un-Read"
-msgstr "Sin leer"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:576
-#, python-format
-msgid "The template name must be unique!"
-msgstr "¡El nombre de la plantilla debe ser único!"
-
-#. module: poweremail
-#: field:poweremail.mailbox,conversation_id:0
-msgid "Conversation"
-msgstr "Conversación"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:336
-#: code:addons/poweremail/poweremail_send_wizard.py:368
-#, python-format
-msgid "No Description"
-msgstr "No hay descripción"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Note: HTML body can't be edited with GTK desktop client."
-msgstr "Nota: El cuerpo HTML no se puede editar con el cliente de escritorio GTK."
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Wizard Complete"
-msgstr "Asistente completo"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Not Applicable"
-msgstr "No aplicable"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
-msgid "Mailbox: Drafts"
-msgstr "Buzón: Borradores"
-
-#. module: poweremail
-#: model:ir.module.module,shortdesc:poweremail.module_meta_information
-msgid "Powerful Email capabilities for Open ERP"
-msgstr "Funcionalidades de correo potentes para OpenERP"
-
-#. module: poweremail
-#: field:poweremail.templates,inline:0
-msgid "Inline HTML"
-msgstr "Inline HTML"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:56
-#, python-format
-msgid "Mako templates not installed"
-msgstr "Las plantillas Mako no están instaladas"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,requested:0
-msgid "No of requested Mails"
-msgstr "Número de mensaje solicitados"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "POP3"
-msgstr "POP3"
-
-#. module: poweremail
-#: help:poweremail.templates,model_data_name:0
-msgid "Model Data Name."
-msgstr "Nombre de los datos del modelo."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Stats"
-msgstr "Estadísticas"
-
-#. module: poweremail
-#: help:poweremail.templates,null_value:0
-msgid "This Value is used if the field is empty."
-msgstr "Este valor se utiliza si el campo se encuentra vacío."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Send/Receive"
-msgstr "Enviar/Recibir"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
-msgid "MailBox"
-msgstr "Buzón"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpssl:0
-msgid "Start a SMTP connection through SSL (Usually port 465)"
-msgstr "Establecer una conexión SMTP utilizando SSL (normalmente puerto 465)"
-
-#. module: poweremail
-#: field:poweremail.templates,table_sub_object:0
-msgid "Table-model"
-msgstr "Modelo-Tabla"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "self - objects pointer"
-msgstr "self - puntero al objecto"
-
-#. module: poweremail
-#: view:ir.actions.server:0
-msgid ""
-"All values for the mail can be configured in the template editor itself."
-msgstr "Todos los valores del correo se pueden configurar en el editor de plantillas."
-
-#. module: poweremail
-#: help:poweremail.templates,stats_interval:0
-msgid ""
-"Number of days used to calculate the send count backwards from today. If "
-"empty or zero, all sent emails are taken into account."
-msgstr "Número de días usados para calcular hacia atrás desde hoy el número de correos enviados. Si está vacío o es cero, se tienen en cuenta todos los correos enviados."
+"\n"
+"\n"
+"<!doctype html>\n"
+"<html>\n"
+"<head></head>\n"
+"<body>\n"
+"Benvolgut/da ${object.login},\n"
+"\n"
+"Això és un email generic de prova per les poweremail_camapign.\n"
+"\n"
+"\n"
+"Atentament,\n"
+"\n"
+"un mort de gana.\n"
+"</body>\n"
+"</html>\n"
+"\n"
+"\t\t\t"
+msgstr "\n\n<!doctype html>\n<html>\n<head></head>\n<body>\nBenvolgut/da ${object.login},\n\nAixò és un email generic de prova per les poweremail_camapign.\n\n\nAtentament,\n\nun mort de gana.\n</body>\n</html>\n\n\t\t\t"
 
 #. module: poweremail
 #: model:ir.module.module,description:poweremail.module_meta_information
@@ -245,213 +60,9 @@ msgid ""
 msgstr "\n  Power Email - Amplia OpenERP con características de correo electrónico.\n  ============================================================================\n  Características\n  ============================================================================\n  1. Varias cuentas de correo electrónico\n  2. Cuentas de compañía y personal\n  3. Seguridad (en desarrollo)\n  4. Carpetas de correo electrónico (bandeja entrada, salida, borrador, ...)\n  5. Enviar correo vía SMTP (SMTP SSL también está soportado)\n  6. Recepción de correos (IMAP & POP3) con SSL y carpetas IMAP\n  7. Diseñador de plantillas sencillo con sistema de actualización automático. No requiere configuración extra.\n  8. Correos electrónicos automáticos según estados de un flujo de trabajo\n  ============================================================================\n  NOTA: Es una versión Beta. Para errores:\n  http://bugs.launchpad.net/poweremail/+filebug (o) https://bugs.launchpad.net/poweremail/+filebug\n  ============================================================================\n  Propuestas y Feedback: sharoon.thomas@openlabs.co.in\n  ============================================================================\n    "
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
-msgid "Mailbox: Outbox"
-msgstr "Buzón: Salida"
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0 view:poweremail.send.wizard:0
-msgid "Cancel"
-msgstr "Cancelar"
-
-#. module: poweremail
-#: field:poweremail.templates,last_send_date:0
-msgid "Last Sent Date"
-msgstr "Fecha del último envío"
-
-#. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
-msgid "Poweremail scheduler"
-msgstr "Planificador poweremail"
-
-#. module: poweremail
-#: field:poweremail.templates,table_required_fields:0
-msgid "Required Fields"
-msgstr "Campos requeridos"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:925
-#, python-format
-msgid "No Subject"
-msgstr "No hay asunto"
-
-#. module: poweremail
-#: field:poweremail.templates,sub_object:0
-msgid "Sub-model"
-msgstr "Sub-modelo"
-
-#. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:154
-#, python-format
-msgid "No model reference defined"
-msgstr "Modelo no referenciado"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "IMAP"
-msgstr "IMAP"
-
-#. module: poweremail
-#: field:poweremail.mailbox,date_mail:0
-msgid "Rec/Sent Date"
-msgstr "Fecha recepción/envío"
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_write:0
-msgid "Send on Update"
-msgstr "Enviar al actualizar"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Server Information"
-msgstr "Información del servidor"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
-msgstr "Nº de correos generados"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isuser:0
-#: field:poweremail.core_accounts,smtpuname:0
-msgid "User Name"
-msgstr "Nombre de usuario"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:348
-#, python-format
-msgid "IMAP Server Login Error: {}"
-msgstr "Error login servidor IMAP: {}"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Suspended"
-msgstr "Suspendida"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
-msgid "Email Mailbox Conversation"
-msgstr "Conversación"
-
-#. module: poweremail
-#: help:poweremail.mailbox,server_ref:0
-msgid "Applicable for inward items only."
-msgstr "Aplicable sólo para los elementos de entrada."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1084
-#, python-format
-msgid "IMAP Folder Statistics for Account: %s: %s"
-msgstr "Estadísticas de carpeta IMAP para la cuenta: %s: %s"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
-msgid "Emails sent"
-msgstr "Correos enviados"
-
-#. module: poweremail
-#: constraint:poweremail.core_accounts:0
-msgid "Error: You are not allowed to have more than 1 account."
-msgstr "Error: No tiene permitido tener mas de 1 cuenta."
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
-msgid "Inbox Conversations"
-msgstr "Conversaciones"
-
-#. module: poweremail
-#: field:poweremail.mailbox,mail_type:0
-msgid "Mail Contents"
-msgstr "Contenido del correo electrónico"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "More information"
-msgstr "Más información"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:329
-#, python-format
-msgid "%s (Email Attachment)"
-msgstr "%s (adjunto correo electrónico)"
-
-#. module: poweremail
-#: field:poweremail.mailbox,state:0 field:poweremail.send.wizard,state:0
-msgid "Status"
-msgstr "Estado"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Outgoing"
-msgstr "Salida"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Intermixed content"
-msgstr "Contenido variado"
-
-#. module: poweremail
-#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Finalitzar"
-msgstr "Finalizar"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
-msgid "wizard.emails.generats.model"
-msgstr "wizard.emails.generats.model"
-
-#. module: poweremail
-#: help:poweremail.templates,sub_object:0
-msgid ""
-"When a relation field is used this field will show you the type of field you"
-" have selected."
-msgstr "Cuando se utiliza un campo de relación, este campo mostrará el tipo de campo que ha seleccionado."
-
-#. module: poweremail
 #: view:poweremail.send.wizard:0
-msgid "Save in Drafts"
-msgstr "Guardar en borradores"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid ""
-"Add here all attachments of the current document you want to include in the "
-"e-mail."
-msgstr "Añada aquí todos los adjuntos del documento actual que quiera incluir en el correo electrónico."
-
-#. module: poweremail
-#: help:poweremail.send.wizard,single_email:0
-#: help:poweremail.templates,single_email:0
-msgid ""
-"Check it if you want to send a single email for several records (the "
-"optional attachment will be generated as a single file for all these "
-"records). If you don't check it, an email with its optional attachment will "
-"be send for each record."
-msgstr "Check it if you want to send a single email for several records (the optional attachment will be generated as a single file for all these records). If you don't check it, an email with its optional attachment will be send for each record."
-
-#. module: poweremail
-#: field:poweremail.template.attachment,search_params:0
-msgid "Search params"
-msgstr "Parámetros de búsqueda"
-
-#. module: poweremail
-#: field:poweremail.preview,save_to_drafts_prev:0
-#: field:poweremail.templates,save_to_drafts:0
-msgid "Save to Drafts"
-msgstr "Guardar en borradores"
-
-#. module: poweremail
-#: field:poweremail.templates,copyvalue:0
-msgid "Expression"
-msgstr "Expresión"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Raw content"
-msgstr "Contenido bruto (raw)"
+msgid " "
+msgstr " "
 
 #. module: poweremail
 #: field:poweremail.mailbox,pem_bcc:0
@@ -459,64 +70,54 @@ msgid " BCC"
 msgstr " BCC"
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_conversation
-msgid "Conversations are groups of related emails"
-msgstr "Conversaciones son grupos de correos relacionados"
+#: field:poweremail.mailbox,pem_cc:0
+msgid " CC"
+msgstr " CC"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,allowed_groups:0
+#: field:poweremail.mailbox,pem_subject:0
+msgid " Subject"
+msgstr "Asunto"
+
+#. module: poweremail
+#: model:poweremail.templates,file_name:poweremail.default_template_poweremail_2
+msgid "${object.number}"
+msgstr "${object.number}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "%s (Email Attachment)"
+msgstr "%s (Email Attachment)"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "%s Mail Form"
+msgstr "%s formulario de correo"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "%s account not found"
+msgstr "%s cuenta no encontrada"
+
+#. module: poweremail
+#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail
 msgid ""
-"Only users from these groups will be allowed to send mails from this ID."
-msgstr "Sólo los usuarios de estos grupos pueden enviar correos desde esta cuenta."
+"<!doctype html>\n"
+"<html>\n"
+"<head></head>\n"
+"<body>\n"
+"This is a demo email\n"
+"</body>\n"
+"</html>"
+msgstr "<!doctype html>\n<html>\n<head></head>\n<body>\nThis is a demo email\n</body>\n</html>"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,name:0
-msgid "Email Account Desc"
-msgstr "Descripción cuenta de correo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:185
-#, python-format
-msgid "No recipient: Email cannot be sent"
-msgstr "Sin destinatario: el correo no se puede enviar"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:679
-#, python-format
-msgid "Copy of template "
-msgstr "Copia de la plantilla"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
-msgid "All emails"
-msgstr "Todos los correos"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Discard Mail"
-msgstr "Cancelar"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Drafts"
-msgstr "Borradores"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:249
-#, python-format
-msgid "Not valid destiny email"
-msgstr "Correo de destino no válido"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_to:0 field:poweremail.templates,def_to:0
-msgid "Recepient (To)"
-msgstr "Para"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Body (HTML-Web Client Only)"
-msgstr "Cuerpo del mensaje (HTML - sólo cliente web)"
+#: field:poweremail.core_accounts,state:0
+msgid "Account Status"
+msgstr "Estado de la cuenta"
 
 #. module: poweremail
 #: field:poweremail.templates,use_filter:0
@@ -524,78 +125,28 @@ msgid "Active Filter"
 msgstr "Filtro activo"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:270
-#, python-format
-msgid "%s account not found"
-msgstr "%s cuenta no encontrada"
+#: field:poweremail.templates,attached_activity:0
+msgid "Activity"
+msgstr "Actividad"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1313
-#: code:addons/poweremail/poweremail_core.py:1317
-#, python-format
-msgid "Folder Error"
-msgstr "Error carpeta"
-
-#. module: poweremail
-#: field:poweremail.templates,table_html:0
-msgid "HTML code"
-msgstr "Código HTML"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "context - current context"
-msgstr "context - contexto actual"
-
-#. module: poweremail
-#: field:poweremail.templates,def_cc:0
-msgid "Default CC"
-msgstr "CC por defecto"
-
-#. module: poweremail
-#: help:poweremail.templates,def_cc:0
-msgid "The default CC for the email. Placeholders can be used here."
-msgstr "El CC por defecto del correo electrónico. Se pueden usar expresiones de campos."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:935
-#, python-format
-msgid "Attachment to mail for %s relation failed Account: %s."
-msgstr "Adjunto de correo para la relación %s ha fallado. Cuenta: %s."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
-msgid "Mailbox: Followup"
-msgstr "Buzón: Seguimiento"
-
-#. module: poweremail
-#: help:poweremail.templates,file_name:0
+#: view:poweremail.send.wizard:0
 msgid ""
-"File name pattern can be specified with placeholders. eg. 2009_SO003.pdf"
-msgstr "Patrón del nombre de fichero. Se puede especificar con expresiones de campos. Ejemplo: ${object.name}.pdf generaría 2009_SO003.pdf"
+"Add here all attachments of the current document you want to include in the "
+"e-mail."
+msgstr "Añada aquí todos los archivos adjuntos del documento actual que desee incluir en el correo."
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:933
-#, python-format
-msgid "Attachment to mail for %s relation success! Account: %s."
-msgstr "¡Adjunto de correo para la relación %s correcto! Cuenta: %s."
+#: view:poweremail.mailbox:0 view:poweremail.templates:0
+msgid "Advanced"
+msgstr "Avanzado"
 
 #. module: poweremail
-#: field:poweremail.send.wizard,rel_model:0
-#: field:poweremail.templates,object_name:0
-#: field:wizard.emails.generats.model,reference:0
-msgid "Model"
-msgstr "Modelo"
-
-#. module: poweremail
-#: help:poweremail.templates,table_sub_object:0
-msgid "This field shows the model you will be using for your table."
-msgstr "Este campo muestra el modelo que utilizará en su tabla."
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_send_wizard
-msgid "This is the wizard for sending mail"
-msgstr "Este es el asistente para enviar correo electrónico"
+#: view:poweremail.send.wizard:0
+msgid ""
+"After clicking send all mails, mails will be sent to outbox and cleared in "
+"next Send/Recieve"
+msgstr "Después de hacer clic en \"Enviar todos los correos\", los correos se enviarán a la bandeja de salida y se eliminarán en el próximo \"Enviar/Recibir\"."
 
 #. module: poweremail
 #: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_all
@@ -604,127 +155,105 @@ msgid "All Accounts"
 msgstr "Todas las cuentas"
 
 #. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr "Todos los correos"
+
+#. module: poweremail
+#: view:ir.actions.server:0
+msgid ""
+"All values for the mail can be configured in the template editor itself."
+msgstr "Todos los valores del correo se pueden configurar en el editor de plantillas."
+
+#. module: poweremail
+#: field:poweremail.core_accounts,allowed_groups:0
+#: field:poweremail.templates,allowed_groups:0 view:poweremail.templates:0
+msgid "Allowed User Groups"
+msgstr "Grupos de usuarios permitidos"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "An error occurred while rendering template id {}:  {}"
+msgstr "Ha ocurrido un error mientras se renderizaba la plantilla con id {}:  {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "An error occurred: %s"
+msgstr "Ha ocurrido un error: %s"
+
+#. module: poweremail
+#: help:poweremail.mailbox,server_ref:0
+msgid "Applicable for inward items only."
+msgstr "Aplicable sólo para los elementos de entrada."
+
+#. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "Check Outgoing Connection"
-msgstr "Comprobar la conexión de salida"
+msgid "Approve Account"
+msgstr "Aprobar la cuenta"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,last_mail_id:0
-msgid "Last Downloaded Mail"
-msgstr "Última descarga de correo"
+#: selection:poweremail.core_accounts,state:0
+msgid "Approved"
+msgstr "Aprobada"
 
 #. module: poweremail
-#: field:poweremail.templates,stats_interval:0
-msgid "Stats Interval"
-msgstr "Intervalo de estadísticas"
+#: field:poweremail.send.wizard,signature:0
+msgid "Attach my signature to mail"
+msgstr "Añadir mi firma al correo"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1318
-#, python-format
-msgid "Select a folder before you save record"
-msgstr "Seleccione una carpeta antes de guardar el registro"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:774
-#: code:addons/poweremail/poweremail_core.py:848
-#, python-format
-msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr "Cabecera del correo %s guardada correctamente con ID: %s para cuenta: %s."
-
-#. module: poweremail
-#: help:poweremail.templates,filter:0
-msgid ""
-"The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
-"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
-msgstr "El código python introducido aquí será ejecutado. Si el resultado es True el correo será enviado y si es False no se enviará.\nEjemplo : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
-
-#. module: poweremail
-#: help:poweremail.templates,allowed_groups:0
-msgid ""
-"Only users from these groups will be allowed to send mails from this "
-"Template."
-msgstr "Sólo los usuarios de estos grupos pueden enviar correos desde esta plantilla."
-
-#. module: poweremail
-#: help:poweremail.templates,auto_email:0
-msgid ""
-"Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
-"Note: Auto email can be enabled only after saving template."
-msgstr "Si selecciona correo electrónico automático se creará una acción de servidor para que se envíe un correo después de crearse/actualizarse un registro.\nAtención: Se puede activar el correo automático sólo después de guardar la plantilla."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:340
-#: code:addons/poweremail/poweremail_core.py:350
-#: code:addons/poweremail/poweremail_core.py:456
-#: code:addons/poweremail/poweremail_core.py:461
-#: code:addons/poweremail/poweremail_core.py:593
-#: code:addons/poweremail/poweremail_core.py:641
-#: code:addons/poweremail/poweremail_core.py:651
-#: code:addons/poweremail/poweremail_core.py:708
-#: code:addons/poweremail/poweremail_core.py:751
-#: code:addons/poweremail/poweremail_core.py:765
-#: code:addons/poweremail/poweremail_core.py:772
-#: code:addons/poweremail/poweremail_core.py:780
-#: code:addons/poweremail/poweremail_core.py:836
-#: code:addons/poweremail/poweremail_core.py:846
-#: code:addons/poweremail/poweremail_core.py:861
-#: code:addons/poweremail/poweremail_core.py:901
-#: code:addons/poweremail/poweremail_core.py:904
-#: code:addons/poweremail/poweremail_core.py:913
-#: code:addons/poweremail/poweremail_core.py:930
-#: code:addons/poweremail/poweremail_core.py:933
-#: code:addons/poweremail/poweremail_core.py:935
-#: code:addons/poweremail/poweremail_core.py:946
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:958
-#: code:addons/poweremail/poweremail_core.py:959
-#: code:addons/poweremail/poweremail_core.py:960
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1011
-#: code:addons/poweremail/poweremail_core.py:1029
-#: code:addons/poweremail/poweremail_core.py:1048
-#: code:addons/poweremail/poweremail_core.py:1059
-#: code:addons/poweremail/poweremail_core.py:1070
-#: code:addons/poweremail/poweremail_core.py:1076
-#: code:addons/poweremail/poweremail_core.py:1082
-#: code:addons/poweremail/poweremail_core.py:1121
-#: code:addons/poweremail/poweremail_core.py:1132
-#: code:addons/poweremail/poweremail_core.py:1138
-#: code:addons/poweremail/poweremail_core.py:1144
-#: code:addons/poweremail/poweremail_core.py:1152
-#: code:addons/poweremail/poweremail_mailbox.py:60
-#: code:addons/poweremail/poweremail_mailbox.py:67
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#: code:addons/poweremail/poweremail_send_wizard.py:275
-#: code:addons/poweremail/poweremail_template.py:54
-#: code:addons/poweremail/poweremail_template.py:68
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_administration_server
-#, python-format
-msgid "Power Email"
-msgstr "Power Email"
-
-#. module: poweremail
-#: help:poweremail.templates,lang:0
-msgid ""
-"The default language for the email. Placeholders can be used here. eg. "
-"${object.partner_id.lang}"
-msgstr "El idioma por defecto del correo electrónico. Se pueden usar expresiones de campos, por ej. ${object.partner_id.lang}"
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Get Mail"
-msgstr "Recupera mensajes"
+#: field:poweremail.templates,attach_record_items:0
+msgid "Attach record items"
+msgstr "Adjuntar elementos"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Log partner events"
-msgstr "Registrar correos como eventos de empresa"
+msgid "Attachment settings"
+msgstr "Configuración del adjunto"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Attachment to mail for %s relation failed Account: %s."
+msgstr "Adjunto de correo para la relación %s ha fallado. Cuenta: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Attachment to mail for %s relation success! Account: %s."
+msgstr "¡Adjunto de correo para la relación %s correcto! Cuenta: %s."
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_attachments_ids:0
+#: field:poweremail.send.wizard,attachment_ids:0
+#: field:poweremail.templates,ir_attachment_ids:0
+#: field:poweremail.templates,tmpl_attachment_ids:0 view:poweremail.mailbox:0
+#: view:poweremail.send.wizard:0 view:poweremail.template.attachment:0
+msgid "Attachments"
+msgstr "Adjuntos"
+
+#. module: poweremail
+#: field:poweremail.templates,auto_email:0
+msgid "Auto Email"
+msgstr "Correo electrónico automático"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Automatisms settings"
+msgstr "Configuración de la automatización"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Available global variables:"
+msgstr "Variables globales disponibles:"
+
+#. module: poweremail
+#: field:poweremail.preview,bcc:0 field:poweremail.send.wizard,bcc:0
+msgid "BCC"
+msgstr "BCC"
 
 #. module: poweremail
 #: field:poweremail.preview,body_html:0 field:poweremail.preview,body_text:0
@@ -734,30 +263,1002 @@ msgid "Body"
 msgstr "Cuerpo del mensaje"
 
 #. module: poweremail
+#: view:poweremail.send.wizard:0 view:poweremail.templates:0
+msgid "Body (HTML)"
+msgstr "Cuerpo del mensaje (HTML)"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Body (Plain Text)"
+msgstr "Cuerpo (texto sin formato)"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Body (Text)"
+msgstr "Cuerpo del mensaje (Texto)"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_html:0
+#: field:poweremail.templates,def_body_html:0
+msgid "Body (Text-Web Client Only)"
+msgstr "Cuerpo del mensaje (Texto - sólo cliente web)"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body HTML"
+msgstr "Cuerpo HTML"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body preview"
+msgstr "Vista previa del cuerpo"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Both HTML & Text"
+msgstr "A la vez HTML y Texto"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
+msgstr "Buscar Correos Relacionados"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
+msgstr "Buscar correos relacionados"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
+msgstr "Buscar emails"
+
+#. module: poweremail
+#: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
+msgid "CC"
+msgstr "CC"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0 view:poweremail.send.wizard:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Cancel·lar"
+msgstr "Cancelar"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Cannot send mails of accounts {} when the addresses list is empty"
+msgstr "No se pueden enviar los correos de las cuentas {} cuando la lista de direcciones está vacía"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_change_folder_email_form
+#: view:wizard.change.folder.email:0
+msgid "Canviar emails de carpeta"
+msgstr "Cambiar correos de buzón"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
+#: view:wizard.change.state.email:0
+msgid "Canviar estat dels emails"
+msgstr "Cambiar el estado de los correos"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Incoming Connection"
+msgstr "Comprobar la conexión de entrada"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Outgoing Connection"
+msgstr "Comprobar la conexión de salida"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid ""
+"Check it if you want to send a single email for several records (the "
+"optional attachment will be generated as a single file for all these r "
+"ecords). If you don't check it, an email with its optional attachment will "
+"be send for each record."
+msgstr "Marque esta opción si desea enviar un único correo electrónico para varios registros (el archivo adjunto opcional se generará como un único archivo para todos estos registros). Si no la marca, se enviará un correo electrónico con su archivo adjunto opcional para cada registro."
+
+#. module: poweremail
+#: help:poweremail.send.wizard,single_email:0
+#: help:poweremail.templates,single_email:0
+msgid ""
+"Check it if you want to send a single email for several records (the "
+"optional attachment will be generated as a single file for all these "
+"records). If you don't check it, an email with its optional attachment will "
+"be send for each record."
+msgstr "Marque esta opción si desea enviar un único correo para varios registros (el archivo adjunto opcional se generará como un único archivo para todos estos registros). Si no la marca, se enviará un correo con su archivo adjunto opcional para cada registro."
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Close"
+msgstr "Cerrar"
+
+#. module: poweremail
+#: field:poweremail.templates,model_data_name:0
+msgid "Code"
+msgstr "Código"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
+msgid "Company"
+msgstr "Compañía"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
+msgid "Company Accounts"
+msgstr "Cuentas de la compañía"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,company:0
+msgid "Company Mail A/c"
+msgstr "Cuenta correo de la compañía"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,full_success:0
+msgid "Complete Success"
+msgstr "El proceso se ha realizado correctamente"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
+msgid "Configuration"
+msgstr "Configuración"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Content"
+msgstr "Contenido"
+
+#. module: poweremail
+#: field:poweremail.mailbox,conversation_id:0
+msgid "Conversation"
+msgstr "Conversación"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_conversation
+msgid "Conversations are groups of related emails"
+msgstr "Conversaciones son grupos de correos relacionados"
+
+#. module: poweremail
+#: help:poweremail.templates,copyvalue:0
+msgid ""
+"Copy and paste the value in the location you want to use a system value."
+msgstr "Copie y pegue el valor en la ubicación que quiera utilizar un valor del sistema."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Copy of template "
+msgstr "Copia de la plantilla"
+
+#. module: poweremail
+#: help:poweremail.templates,table_html:0
+msgid ""
+"Copy this html code to your HTML message body for displaying the info in "
+"your mail."
+msgstr "Copie este código HTML en el cuerpo del mensaje HTML para mostrar la información en su correo electrónico."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Core connection for the given ID does not exist"
+msgstr "La conexión básica para el ID dado no existe"
+
+#. module: poweremail
+#: help:poweremail.templates,server_action:0
+msgid "Corresponding server action is here."
+msgstr "La acción correspondiente de servidor está aquí."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
+"Description: {error}"
+msgstr "No se pudo crear el correo \"{subject}\" de la Cuenta \"{account.name}\".\nDescripción: {error}"
+
+#. module: poweremail
+#: help:poweremail.templates,send_on_create:0
+msgid ""
+"Create an e-mail when a new record is created. The instance where the record"
+" is created must be restarted for the changes to take effect."
+msgstr "Crear un correo electrónico cuando se cree un nuevo registro. La instancia en la que se crea el registro debe reiniciarse para que los cambios surtan efecto."
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Create send email wizard"
+msgstr "Crear asistente de envío de correo"
+
+#. module: poweremail
+#: field:poweremail.mailbox,create_date:0
+msgid "Created date"
+msgstr "Fecha de creación"
+
+#. module: poweremail
+#: field:poweremail.mailbox,write_date:0
+msgid "Date modified"
+msgstr "Fecha de moodificación"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Datetime Extraction failed. Date: %s\n"
+"Error: %s"
+msgstr "Extracción de fecha y hora ha fallado. Fecha: %s\nError: %s"
+
+#. module: poweremail
+#: field:poweremail.templates,def_bcc:0
+msgid "Default BCC"
+msgstr "BCC por defecto"
+
+#. module: poweremail
+#: field:poweremail.templates,def_cc:0
+msgid "Default CC"
+msgstr "CC por defecto"
+
+#. module: poweremail
+#: field:poweremail.templates,def_subject:0
+msgid "Default Subject"
+msgstr "Asunto por defecto"
+
+#. module: poweremail
+#: field:poweremail.templates,def_priority:0
+msgid "Default priority"
+msgstr "Prioridad por defecto"
+
+#. module: poweremail
+#: help:poweremail.templates,def_priority:0
+msgid "Default priority for auto generated emails"
+msgstr "Prioridad por defecto para los correos generados automáticamente"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Deletion of Record failed"
+msgstr "La eliminación del registro ha fallado"
+
+#. module: poweremail
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
+msgid "Demo email subject for user ${object.login}"
+msgstr "Asunto de correo de demostración para el usuario ${object.login}"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Discard Mail"
+msgstr "Cancelar"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Django templates not installed"
+msgstr "Las plantillas Django no están instaladas"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr "No descargar los adjuntos automáticamente"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Download Full Mail"
+msgstr "Descargar todo el correo"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Downloaded & saved %s attachments Account: %s."
+msgstr "Descargados y guardados %s adjuntos. Cuenta: %s."
+
+#. module: poweremail
 #: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts
 #: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts_company
 msgid "Drafts"
 msgstr "Borradores"
 
 #. module: poweremail
-#: view:poweremail.preview:0
-msgid "Send Email"
-msgstr "Enviar correo"
+#: view:poweremail.templates:0
+msgid "Dynamic attachments (reports)"
+msgstr "Adjuntos dinámicos (informes)"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Editor (HTML)"
+msgstr "Editor (HTML)"
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,name:0
+msgid "Email Account"
+msgstr "Cuenta de correo"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,name:0
+msgid "Email Account Desc"
+msgstr "Descripción cuenta de correo"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
+msgid "Email Basic Templates"
+msgstr "Plantillas de correo básicas"
+
+#. module: poweremail
+#: view:ir.actions.server:0
+msgid "Email Configuration"
+msgstr "Configuración correo electrónico"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,email_id:0
+msgid "Email ID"
+msgstr "ID correo electrónico"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
+msgid "Email Mailbox Conversation"
+msgstr "Conversación"
+
+#. module: poweremail
+#: field:ir.actions.report.xml,poweremail_template_ids:0
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
+msgid "Email Templates"
+msgstr "Plantillas de correo electrónico"
+
+#. module: poweremail
+#: field:poweremail.preview,enforce_from_account:0
+msgid "Email account"
+msgstr "Cuenta de correo"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Email body"
+msgstr "Cuerpo del correo electrónico"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Email sending failed for one or more objects."
+msgstr "El envío de correo ha fallado en uno o varios objetos."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Email sent successfully"
+msgstr "Correo enviado correctamente"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Email will be sent again"
+msgstr "El correo se volverá a enviar"
+
+#. module: poweremail
+#: help:poweremail.preview,enforce_from_account:0
+msgid "Email will be sent from this account."
+msgstr "El correo se enviará desde esta cuenta."
+
+#. module: poweremail
+#: view:wizard.change.state.email:0
+msgid "Emails canviats d'estat!"
+msgstr "Estado de los correos cambiado!"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0
+msgid "Emails canviats de carpeta!"
+msgstr "Correos cambiados de buzón!"
+
+#. module: poweremail
+#: help:poweremail.templates,send_immediately:0
+msgid ""
+"Emails created from this template will be sent immediately without going "
+"through outbox folder."
+msgstr "Los correos creados a partir de esta plantilla se enviarán inmediatamente sin pasar por la bandeja de salida."
+
+#. module: poweremail
+#: view:wizard.send.email:0
+msgid "Emails enviats!"
+msgstr "Correos enviados!"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Emails for multiple items saved in outbox."
+msgstr "Correos para múltiples elementos guardados en el buzón de salida."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
+msgid "Emails in error folder"
+msgstr "Correos en la carpeta de errores"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
+msgid "Emails sent"
+msgstr "Correos enviados"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
+msgid "Emails sent today"
+msgstr "Correos enviados hoy"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
+msgid "Emails to sent"
+msgstr "Correos a enviar"
+
+#. module: poweremail
+#: help:poweremail.templates,enforce_from_account:0
+msgid "Emails will be sent only from this account."
+msgstr "Los correos electrónicos se enviaran sólo desde esta cuenta."
+
+#. module: poweremail
+#: selection:poweremail.preview,state:0
+#: selection:wizard.change.folder.email,state:0
+#: selection:wizard.change.state.email,wiz_state:0
+#: selection:wizard.send.email,state:0
+msgid "End"
+msgstr "Fin"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Endavant"
+msgstr "Adelante"
+
+#. module: poweremail
+#: field:poweremail.templates,enforce_from_account:0
+msgid "Enforce From Account"
+msgstr "Fuerza desde la cuenta"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,iserver:0
+msgid "Enter name of incoming server, eg: imap.gmail.com"
+msgstr "Introduzca el nombre de servidor del correo de entrada, por ejemplo: imap.gmail.com"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpserver:0
+msgid "Enter name of outgoing server, eg: smtp.gmail.com"
+msgstr "Escriba el nombre del servidor de correo de salida, por ejemplo: smtp.gmail.com"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
+msgstr "Introduzca el número del puerto, por ejemplo para SMTP el 587."
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
+#: view:wizard.send.email:0
+msgid "Enviar emails"
+msgstr "Enviar correos"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_serveraction.py:0
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
+#: selection:poweremail.preview,state:0
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error receiving mail: %s"
+msgstr "Error recibiendo correo: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending email with id {}: {}"
+msgstr "Error enviando el correo con id {}: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending mail: %s"
+msgstr "Error enviando correo: %s"
+
+#. module: poweremail
+#: constraint:poweremail.core_accounts:0
+msgid "Error: You are not allowed to have more than 1 account."
+msgstr "Error: No tiene permitido tener mas de 1 cuenta."
+
+#. module: poweremail
+#: field:wizard.change.state.email,estat:0
+msgid "Estat"
+msgstr "Estado"
+
+#. module: poweremail
+#: field:poweremail.templates,copyvalue:0
+msgid "Expression"
+msgstr "Expresión"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Expression builder"
+msgstr "Generador de expresiones"
+
+#. module: poweremail
+#: field:poweremail.preview,env:0 view:poweremail.preview:0
+msgid "Extra scope variables"
+msgstr "Variables extra del ámbito (scope) "
+
+#. module: poweremail
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
+msgid "Factura ${object.number}"
+msgstr "Factura ${object.number}"
+
+#. module: poweremail
+#: field:poweremail.templates,model_object_field:0
+msgid "Field"
+msgstr "Campo"
+
+#. module: poweremail
+#: field:poweremail.templates,file_name:0
+msgid "File Name Pattern"
+msgstr "Patrón nombre de fichero"
+
+#. module: poweremail
+#: field:poweremail.template.attachment,file_name:0
+msgid "File name"
+msgstr "Nombre del fichero"
+
+#. module: poweremail
+#: help:poweremail.templates,file_name:0
+msgid ""
+"File name pattern can be specified with placeholders. eg. 2009_SO003.pdf"
+msgstr "Patrón del nombre de fichero. Se puede especificar con expresiones de campos. Ejemplo: ${object.name}.pdf generaría 2009_SO003.pdf"
+
+#. module: poweremail
+#: field:poweremail.templates,filter:0 view:poweremail.templates:0
+msgid "Filter"
+msgstr "Filtro"
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Finalitzar"
+msgstr "Finalizar"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,rec_headers_den_mail:0
+msgid "First Receive headers, then download mail"
+msgstr "Primero se descargan los encabezados, después el correo"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isfolder:0 field:poweremail.mailbox,folder:0
+#: field:wizard.change.folder.email,folder:0
+msgid "Folder"
+msgstr "Carpeta"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Folder Error"
+msgstr "Error carpeta"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isfolder:0
+msgid ""
+"Folder to be used for downloading IMAP mails.\n"
+"Click on adjacent button to select from a list of folders."
+msgstr "Carpeta a usar para recibir los correos IMAP.\nSeleccione una de la lista de carpetas haciendo clic en el botón."
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
+msgid "Follow-up"
+msgstr "Seguimiento"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isport:0
+msgid "For example IMAP: 993,POP3:995"
+msgstr "Por ejemplo IMAP: 993, POP3: 995."
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_from:0
+msgid "From"
+msgstr "Desde"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,from:0
+msgid "From Account"
+msgstr "Desde la cuenta"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "From Poweremail Mailbox {} Original email as {}"
+msgstr "Desde el buzón {} correo original como {}"
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "Generated Email"
+msgstr "Correo generado"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Get Mail"
+msgstr "Recupera mensajes"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "HTML Body"
+msgstr "Cuerpo del mensaje HTML"
+
+#. module: poweremail
+#: field:poweremail.templates,table_html:0
+msgid "HTML code"
+msgstr "Código HTML"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "HTML otherwise Text"
+msgstr "HTML, en caso contrario Texto"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Has Attachments"
+msgstr "Tiene adjuntos"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
+msgstr "Cabecera del correo %s guardada correctamente con ID: %s para cuenta: %s."
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "High"
+msgstr "Alta"
+
+#. module: poweremail
+#: field:poweremail.mailbox,history:0
+msgid "History"
+msgstr "Historial"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "IMAP"
+msgstr "IMAP"
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,folder:0
+msgid "IMAP Folder"
+msgstr "Carpeta IMAP"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
+msgid "IMAP Folder Selection Wizard"
+msgstr "Asistente selección carpeta IMAP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder Statistics for Account: %s: %s"
+msgstr "Estadísticas de carpeta IMAP para la cuenta: %s: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account: %s."
+msgstr "Carpeta IMAP seleccionada correctamente. Cuenta: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account:%s."
+msgstr "Carpeta IMAP seleccionada correctamente. Cuenta:%s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
+msgstr "Correo IMAP -> Error al crear buzón. Cuenta: %s, Correo: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
+msgstr "Correo IMAP -> Error al crear buzón. Cuenta: %s, Correo: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Connected & logged in successfully Account: %s."
+msgstr "Servidor IMAP conectado y autenticado correctamente. Cuenta: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Error: {}"
+msgstr "Error del servidor IMAP: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Error"
+msgstr "Error carpeta servidor IMAP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
+msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"IMAP Server Folder Selection Error Account: %s Error: %s.\n"
+"Check account settings if you have selected a folder."
+msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s.\nCompruebe si ha seleccionado una carpeta en la configuración de la cuenta."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
+msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Login Error: {}"
+msgstr "Error login servidor IMAP: {}"
+
+#. module: poweremail
+#: help:poweremail.templates,inline:0
+msgid "If the option is checked, the CSS will be inlined inside the HTML"
+msgstr "Si se marca la opción, el CSS se incrustará en los atributos de los elementos HTML"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "In coming connection test failed"
+msgstr "El test de la conexión de entrada ha fallado"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
+msgid "Inbox"
+msgstr "Entrada"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
+msgid "Inbox Conversations"
+msgstr "Conversaciones"
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "SMTP Server"
-msgstr "Servidor SMTP"
+msgid "Incoming"
+msgstr "Entrada"
 
 #. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send all mails"
-msgstr "Enviar todos los correos"
+#: field:poweremail.core_accounts,iserver:0
+msgid "Incoming Server"
+msgstr "Servidor de entrada"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,iserver_type:0
-msgid "Server Type"
-msgstr "Tipo de servidor"
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming Test Connection Was Successful"
+msgstr "El test de la conexión de entrada ha sido un éxito"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming port is not defined"
+msgstr "No se ha definido el puerto de entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server is not defined"
+msgstr "No se ha definido el servidor de entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Incoming server login attempt dropped Account: %s\n"
+"Check if Incoming server attributes are complete."
+msgstr "Intento de autenticación con el servidor de entrada abortado. Cuenta:%s.\nComprueba si los datos del servidor de entrada están completos."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Incoming server login attempt dropped Account: %s Check if Incoming server "
+"attributes are complete."
+msgstr "Intento de autenticación con el servidor de entrada abortado. Cuenta: %s. Comprueba si los datos del servidor de entrada están completos."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server password is not defined"
+msgstr "No se ha definido la contraseña del servidor de entrada"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server user name is not defined"
+msgstr "No se ha definido el nombre del usuario del servidor de entrada"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Information"
+msgstr "Información"
+
+#. module: poweremail
+#: selection:poweremail.preview,state:0
+#: selection:wizard.change.folder.email,state:0
+#: selection:wizard.change.state.email,wiz_state:0
+#: selection:wizard.send.email,state:0
+msgid "Init"
+msgstr "Init"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,state:0
+msgid "Initiated"
+msgstr "Iniciada"
+
+#. module: poweremail
+#: field:poweremail.templates,inline:0
+msgid "Inline HTML"
+msgstr "Inline HTML"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Insert Simple Field"
+msgstr "Insertar campo simple"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Insert Table"
+msgstr "Insertar tabla"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Intermixed content"
+msgstr "Contenido variado"
+
+#. module: poweremail
+#: constraint:ir.ui.view:0
+msgid ""
+"Invalid XML for View Architecture! Check server logs for details (view name,"
+" model, line number and RNG error)."
+msgstr "¡XML no válido para la arquitectura de la vista! Revisa los registros del servidor para obtener más detalles (nombre de la vista, modelo, número de línea y error RNG)."
+
+#. module: poweremail
+#: constraint:ir.cron:0
+msgid "Invalid arguments"
+msgstr "Invalid arguments"
+
+#. module: poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr "Nombre del módulo inválido en la definición de la acción."
+
+#. module: poweremail
+#: field:poweremail.preview,lang:0 field:poweremail.templates,lang:0
+msgid "Language"
+msgstr "Idioma"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,last_mail_id:0
+msgid "Last Downloaded Mail"
+msgstr "Última descarga de correo"
+
+#. module: poweremail
+#: field:poweremail.templates,last_send_date:0
+msgid "Last Sent Date"
+msgstr "Fecha del último envío"
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
+msgstr "Listar correos relacionados"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Log partner events"
+msgstr "Registrar correos como eventos de empresa"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Logs"
+msgstr "Registros"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Low"
+msgstr "Baja"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail %s Saved successfully as ID: %s for Account: %s."
+msgstr "Correo %s guardado correctamente como ID: %s para cuenta: %s."
+
+#. module: poweremail
+#: field:poweremail.mailbox,mail_type:0
+msgid "Mail Contents"
+msgstr "Contenido del correo electrónico"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Mail Details"
+msgstr "Detalle del correo electrónico"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,send_pref:0
+msgid "Mail Format"
+msgstr "Formato del correo electrónico"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Mail fetch exception"
+msgstr "Excepción de extracción de correo"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
+"Error: %s"
+msgstr "El correo desde la cuenta %s ha fallado en la autenticación. Causa probable: No se puede autenticar al servidor\nError: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail from Account %s failed. Probable Reason: Account not approved"
+msgstr "Correo desde la cuenta %s ha fallado. Motivo probable: Cuenta no aprobada."
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
+msgid "MailBox"
+msgstr "Buzón"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
+msgstr "Buzón: Todos los correos"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
+msgid "Mailbox: Drafts"
+msgstr "Buzón: Borradores"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
+msgid "Mailbox: Error"
+msgstr "Buzón: Error"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
+msgid "Mailbox: Followup"
+msgstr "Buzón: Seguimiento"
 
 #. module: poweremail
 #: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree
@@ -766,58 +1267,508 @@ msgid "Mailbox: Inbox"
 msgstr "Buzón: Entrada"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:401
-#, python-format
-msgid "Incoming port is not defined"
-msgstr "No se ha definido el puerto de entrada"
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
+msgid "Mailbox: Outbox"
+msgstr "Buzón: Salida"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1018
-#, python-format
-msgid ""
-"The expression in 'Reference of the report' field must contain the 'object' "
-"variable."
-msgstr "La expresión en el campo 'Referencia del informe' debe contener la variable 'object'."
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
+msgid "Mailbox: Sending"
+msgstr "Buzón: Enviando"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:275
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
+msgid "Mailbox: Sent"
+msgstr "Buzón: Enviados"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
+msgid "Mailbox: Trash"
+msgstr "Buzón: Papelera"
+
+#. module: poweremail
+#: selection:poweremail.templates,template_language:0
+msgid "Mako Templates"
+msgstr "Plantillas Mako"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "Email sending failed for one or more objects."
-msgstr "El envío de correo ha fallado en uno o varios objetos."
+msgid "Mako templates not installed"
+msgstr "Las plantillas Mako no están instaladas"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_message_id:0
+msgid "Message-Id"
+msgstr "Message-Id"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,rel_model:0
+#: field:poweremail.templates,object_name:0
+#: field:wizard.emails.generats.model,reference:0
+msgid "Model"
+msgstr "Modelo"
+
+#. module: poweremail
+#: help:poweremail.templates,model_data_name:0
+msgid "Model Data Name."
+msgstr "Nombre de los datos del modelo."
+
+#. module: poweremail
+#: field:poweremail.templates,model_int_name:0
+msgid "Model Internal Name"
+msgstr "Nombre del modelo interno"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "More information"
+msgstr "Más información"
 
 #. module: poweremail
 #: selection:poweremail.send.wizard,state:0
-msgid "Send Type"
-msgstr "Tipo de envío"
+msgid "Multiple Mail Wizard Step 1"
+msgstr "Asistente correo múltiple - Paso 1"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1029
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
+msgid "My Account"
+msgstr "Mi cuenta"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
+msgid "My Accounts"
+msgstr "Mis cuentas"
+
+#. module: poweremail
+#: field:poweremail.conversation,name:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: poweremail
+#: field:poweremail.templates,name:0
+msgid "Name of Template"
+msgstr "Nombre de la plantilla"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,company:0
+msgid "No"
+msgstr "No"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "No Description"
+msgstr "No hay descripción"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "No Subject"
+msgstr "No hay asunto"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No information on which mail should be fetched fully"
+msgstr "No existe información sobre que correo debería ser extraído completamente"
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "No model reference defined"
+msgstr "No se ha definido ninguna referencia de modelo"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
+msgstr "Nº de correos generados"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,requested:0
+msgid "No of requested Mails"
+msgstr "Nº de correos solicitados"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
 msgid ""
-"Incoming server login attempt dropped Account: %s Check if Incoming server "
-"attributes are complete."
-msgstr "Intento de autenticación con el servidor de entrada abortado. Cuenta: %s. Comprueba si los datos del servidor de entrada están completos."
+"No personal email accounts are configured for you. \n"
+"Either ask admin to enforce an account for this template or get yourself a personal power email account."
+msgstr "No se han configurado cuentas de correo personales para usted.\nSolicite al administrador que le proporcione una cuenta para esta plantilla o obtenga usted mismo una cuenta de correo personal de poweremail."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No recipient: Email cannot be sent"
+msgstr "Sin destinatario: el correo no se puede enviar"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Normal"
+msgstr "Normal"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Not Applicable"
+msgstr "No aplicable"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Not valid destiny email"
+msgstr "Correo de destino no válido"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Note: HTML body can't be edited with GTK desktop client."
+msgstr "Nota: El cuerpo HTML no se puede editar con el cliente de escritorio GTK."
+
+#. module: poweremail
+#: field:poweremail.templates,null_value:0
+msgid "Null Value"
+msgstr "Valor nulo"
+
+#. module: poweremail
+#: help:poweremail.templates,stats_interval:0
+msgid ""
+"Number of days used to calculate the send count backwards from today. If "
+"empty or zero, all sent emails are taken into account."
+msgstr "Número de días utilizados para calcular el número de envíos hacia atrás desde hoy. Si está vacío o es cero, se tienen en cuenta todos los correos enviados."
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "OK"
+msgstr "OK"
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Ok"
+msgstr "Aceptar"
+
+#. module: poweremail
+#: help:poweremail.templates,record_attachment_categories:0
+msgid ""
+"Only attach record attachments with the included categories in case there's "
+"any."
+msgstr "Adjuntar únicamente adjuntos del registro con las categorías incluidas en el caso de que haya alguna"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,allowed_groups:0
+msgid ""
+"Only users from these groups will be allowed to send mails from this ID."
+msgstr "Sólo los usuarios de estos grupos pueden enviar correos desde esta cuenta."
+
+#. module: poweremail
+#: help:poweremail.templates,allowed_groups:0
+msgid ""
+"Only users from these groups will be allowed to send mails from this "
+"Template."
+msgstr "Sólo los usuarios de estos grupos pueden enviar correos desde esta plantilla."
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "OpenObject Code Filter:"
+msgstr "Filtro de código OpenObject:"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr "Correo original"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Other settings"
+msgstr "Otras configuraciones"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company_others
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal_others
+msgid "Others"
+msgstr "Otros"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Out going connection test failed"
+msgstr "El test de la conexión de salida ha fallado"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
+msgid "Outbox"
+msgstr "Salida"
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "Approve Account"
-msgstr "Aprobar la cuenta"
+msgid "Outgoing"
+msgstr "Salida"
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "POP3"
+msgstr "POP3"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Connected & logged in successfully Account: %s."
+msgstr "Servidor POP3 conectado y autenticado correctamente. Cuenta: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Error Account: %s Error: %s."
+msgstr "Error del servidor POP3 en la cuenta %s. Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Login Error Account: %s Error: %s."
+msgstr "Error de autenticación servidor POP3. Cuenta: %s Error: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s"
+msgstr "Estadísticas POP3: %s correos de tamaño %s para la cuenta: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
+msgstr "Estadísticas POP3: %s correos de tamaño %s para la cuenta: %s:"
+
+#. module: poweremail
+#: field:poweremail.templates,partner_event:0
+msgid "Partner ID to log Events"
+msgstr "ID empresa para registrar eventos"
+
+#. module: poweremail
+#: help:poweremail.templates,partner_event:0
+msgid ""
+"Partner ID who an email event is logged.\n"
+"Placeholders can be used here. eg. ${object.partner_id.id}\n"
+"You must install the mail_gateway module to see the mail events in partner form.\n"
+"If you also want to record the link to the object that sends the email, you must to add this object in the 'Administration/Low Level Objects/Requests/Accepted Links in Requests' menu (or 'ir.attachment' to record the attachments)."
+msgstr "ID de empresa donde debe registrarse un evento de correo.\nSe pueden usar expresiones de campos. Por ej. ${object.partner_id.id}\nDebe instalar el módulo mail_gateway para ver los eventos de correo en el formulario de empresa.\nSi también desea guardar el enlace hacia el objeto que envía el correo, debe añadir este objeto en el menú 'Administración/Personalización/Objetos de bajo nivel/Solicitudes/Tipos de referencias en solicitudes' (o 'ir.attachment' para guardar los adjuntos)."
+
+#. module: poweremail
+#: field:poweremail.core_accounts,ispass:0
+#: field:poweremail.core_accounts,smtppass:0
+msgid "Password"
+msgstr "Contraseña"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
+msgid "Personal"
+msgstr "Personal"
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
+msgid "Personal Account"
+msgstr "Cuenta personal"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
+msgid "Personal Accounts"
+msgstr "Cuentas personales"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Plain Text"
+msgstr "Texto plano"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Plain Text & HTML with no attachments"
+msgstr "Texto plano y HTML sin adjunto"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_serveraction.py:0
+#, python-format
+msgid "Please specify an template to use for auto email in poweremail!"
+msgstr "¡Indique una plantilla para usar para los correos automáticos en poweremail!"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isport:0
+msgid "Port"
+msgstr "Puerto"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#: code:addons/poweremail/poweremail_template.py:0
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_administration_server
+#, python-format
+msgid "Power Email"
+msgstr "Power Email"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email All Emails"
+msgstr "Todos los correos"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Power Email Configuration"
+msgstr "Configuración"
+
+#. module: poweremail
+#: view:poweremail.conversation:0
+msgid "Power Email Conversation"
+msgstr "Conversación"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Drafts"
+msgstr "Borradores"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Error"
+msgstr "Error de Power Email"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Follow Up"
+msgstr "Seguimiento Power Email"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Inbox"
+msgstr "Entrada"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_mailbox
+msgid "Power Email Mailbox included all type inbox,outbox,junk.."
+msgstr "Power Mail incluye todo tipo de buzones de correo: entrada, salida, basura, ..."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Outbox"
+msgstr "Bandeja de Salida"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Power Email Preview"
+msgstr "Vista previa"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Sent"
+msgstr "Enviado"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_preview
+msgid "Power Email Template Preview"
+msgstr "Previsualización de la plantilla"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Power Email Templates"
+msgstr "Plantillas de correo electrónico"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_templates
+msgid "Power Email Templates for Models"
+msgstr "Plantillas para los modelos"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Trash"
+msgstr "Papelera"
+
+#. module: poweremail
+#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
+msgid "Poweremail scheduler"
+msgstr "Planificador poweremail"
+
+#. module: poweremail
+#: model:ir.module.module,shortdesc:poweremail.module_meta_information
+msgid "Powerful Email capabilities for Open ERP"
+msgstr "Funcionalidades de correo potentes para OpenERP"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Preview"
+msgstr "Vista previa"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Preview Email"
+msgstr "Vista previa del correo"
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Preview Template"
+msgstr "Previsualizar plantilla"
+
+#. module: poweremail
+#: field:poweremail.mailbox,priority:0 field:poweremail.send.wizard,priority:0
+msgid "Priority"
+msgstr "Prioridad"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid ""
+"Programming Error in _get_pop3_server method. The record received is "
+"invalid."
+msgstr "Error de programación en el método _get_pop3_server. El registro que se ha recibido no es valido."
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Raw content"
+msgstr "Contenido bruto (raw)"
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Read"
+msgstr "Leído"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Reason: %s"
+msgstr "Motivo: %s"
+
+#. module: poweremail
+#: field:poweremail.mailbox,date_mail:0
+msgid "Rec/Sent Date"
+msgstr "Fecha recepción/envío"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_recd:0
+msgid "Received at"
+msgstr "Recibido el"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_to:0 field:poweremail.templates,def_to:0
+msgid "Recepient (To)"
+msgstr "Para"
+
+#. module: poweremail
+#: field:poweremail.templates,record_attachment_categories:0
+msgid "Record attachment categories"
+msgstr "Categorías de los adjuntos del registro"
+
+#. module: poweremail
+#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
+msgid "Reenviar emails amb error"
+msgstr "Reenviar correos con error"
 
 #. module: poweremail
 #: field:poweremail.send.wizard,rel_model_ref:0
 msgid "Referred Document"
-msgstr "Documento relacionado"
-
-#. module: poweremail
-#: help:poweremail.templates,def_to:0
-msgid "The default recepient of email. Placeholders can be used here."
-msgstr "El destinatario por defecto del correo electrónico. Se pueden usar expresiones de campos."
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,pem_body_text:0
-#: field:poweremail.templates,def_body_text:0
-msgid "Standard Body (Text)"
-msgstr "Cuerpo del mensaje (texto)"
+msgstr "Documento de referencia"
 
 #. module: poweremail
 #: field:poweremail.conversation,mails:0
@@ -830,240 +1781,25 @@ msgid "Related Server Action"
 msgstr "Acción de servidor relacionada"
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_mailbox
-msgid "Power Email Mailbox included all type inbox,outbox,junk.."
-msgstr "Power Mail incluye todo tipo de buzones de correo: entrada, salida, basura, ..."
+#: field:poweremail.core_accounts,user:0
+msgid "Related User"
+msgstr "Usuario relacionado"
 
 #. module: poweremail
-#: field:poweremail.preview,subject:0 field:poweremail.send.wizard,subject:0
-msgid "Subject"
-msgstr "Asunto"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:403
-#, python-format
-msgid "Incoming server user name is not defined"
-msgstr "No se ha definido el nombre del usuario del servidor de entrada"
-
-#. module: poweremail
-#: selection:poweremail.preview,state:0
-#: selection:wizard.change.folder.email,state:0
-#: selection:wizard.change.state.email,wiz_state:0
-#: selection:wizard.send.email,state:0
-msgid "End"
-msgstr "Fin"
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar emails"
-msgstr "Buscar emails"
-
-#. module: poweremail
-#: help:poweremail.templates,send_on_write:0
-msgid "Sends an e-mail when a document is modified."
-msgstr "Envía un correo electrónico cuando se modifica un documento."
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Follow Up"
-msgstr "Seguimiento Power Email"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Standard Body"
-msgstr "Cuerpo del mensaje (estándar)"
+#: view:ir.actions.report.xml:0
+msgid "Related email templates"
+msgstr "Plantillas de correo relacionadas"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Email body"
-msgstr "Cuerpo del correo electrónico"
+msgid "Remove send email wizard"
+msgstr "Eliminar asistente de envío de correo"
 
 #. module: poweremail
-#: field:poweremail.templates,name:0
-msgid "Name of Template"
-msgstr "Nombre de la plantilla"
-
-#. module: poweremail
-#: field:poweremail.templates,send_count:0
-msgid "Send Count"
-msgstr "Número de envíos"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:334
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
 msgid "Report"
 msgstr "Informe"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:642
-#, python-format
-msgid ""
-"Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
-"Description: {error}"
-msgstr "No se pudo crear el correo \"{subject}\" de la Cuenta \"{account.name}\".\nDescripción: {error}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:316
-#: code:addons/poweremail/poweremail_core.py:436
-#, python-format
-msgid "Reason: %s"
-msgstr "Motivo: %s"
-
-#. module: poweremail
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr "¡XML inválido para la estructura de la vista!"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_preview
-msgid "Power Email Template Preview"
-msgstr "Previsualización de la plantilla"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtptls:0
-msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
-msgstr "Establecer una conexión TLS después de la conexión SMTP (normalmente puerto 587)"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Body (Plain Text)"
-msgstr "Cuerpo del mensaje (Texto plano)"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Outbox"
-msgstr "Bandeja de Salida"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:310
-#, python-format
-msgid "SMTP Test Connection Was Successful"
-msgstr "El test de la conexión SMTP ha sido un éxito"
-
-#. module: poweremail
-#: field:poweremail.conversation,from_abstract:0
-msgid "unknown"
-msgstr "desconocido"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,company:0
-msgid "Company Mail A/c"
-msgstr "Cuenta correo de la compañía"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1144
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
-msgstr "Estadísticas POP3: %s correos de tamaño %s para la cuenta: %s:"
-
-#. module: poweremail
-#: help:poweremail.templates,use_filter:0
-msgid ""
-"This option allow you to add a custom python filter before sending a mail"
-msgstr "This option allow you to add a custom python filter before sending a mail"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_template_attachment
-msgid "poweremail.template.attachment"
-msgstr "poweremail.template.attachment"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:913
-#, python-format
-msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
-msgstr "Correo IMAP -> Error al crear buzón. Cuenta: %s, Correo: %s"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send now"
-msgstr "Enviar ahora"
-
-#. module: poweremail
-#: help:poweremail.templates,report_template_object_reference:0
-msgid ""
-"The evaluation of this field should return the ID of the related object. For"
-" example, use: object.related_model_id.id. This ensures that the template "
-"can correctly reference the object."
-msgstr "La evaluación de este campo debe devolver el ID del objeto relacionado. Por ejemplo, usa: object.related_model_id.id. Esto garantiza que la plantilla pueda referenciar correctamente el objeto."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
-msgid "Mailbox: Trash"
-msgstr "Buzón: Papelera"
-
-#. module: poweremail
-#: field:poweremail.templates,model_int_name:0
-msgid "Model Internal Name"
-msgstr "Nombre del modelo interno"
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body preview"
-msgstr "Vista previa del cuerpo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:960
-#, python-format
-msgid "IMAP Folder selected successfully Account:%s."
-msgstr "Carpeta IMAP seleccionada correctamente. Cuenta:%s."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Static attachments"
-msgstr "Adjuntos estáticos"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Preview Template"
-msgstr "Previsualizar plantilla"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,isfolder:0
-msgid ""
-"Folder to be used for downloading IMAP mails.\n"
-"Click on adjacent button to select from a list of folders."
-msgstr "Carpeta a usar para recibir los correos IMAP.\nSeleccione una de la lista de carpetas haciendo clic en el botón."
-
-#. module: poweremail
-#: field:poweremail.send.wizard,from:0
-msgid "From Account"
-msgstr "Desde la cuenta"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_templates
-msgid "Power Email Templates for Models"
-msgstr "Plantillas para los modelos"
-
-#. module: poweremail
-#: field:poweremail.preview,enforce_from_account:0
-msgid "Email account"
-msgstr "Cuenta de correo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:782
-#: code:addons/poweremail/poweremail_core.py:863
-#, python-format
-msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
-msgstr "Correo IMAP -> Error al crear buzón. Cuenta: %s, Correo: %s"
-
-#. module: poweremail
-#: field:poweremail.preview,lang:0 field:poweremail.templates,lang:0
-msgid "Language"
-msgstr "Idioma"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1268
-#: code:addons/poweremail/poweremail_core.py:1271
-#, python-format
-msgid "An error occurred: %s"
-msgstr "Ha ocurrido un error: %s"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:594
-#, python-format
-msgid "Cannot send mails of accounts {} when the addresses list is empty"
-msgstr "No se pueden enviar los correos de las cuentas {} cuando la lista de direcciones está vacía"
 
 #. module: poweremail
 #: field:poweremail.send.wizard,report:0
@@ -1071,14 +1807,92 @@ msgid "Report File Name"
 msgstr "Nombre del fichero del informe"
 
 #. module: poweremail
-#: field:poweremail.templates,table_model_object_field:0
-msgid "Table Field"
-msgstr "Campo de la tabla"
+#: field:poweremail.preview,report:0
+msgid "Report Name"
+msgstr "Nombre del informe"
 
 #. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,history:0
-msgid "History"
-msgstr "Historial"
+#: field:poweremail.template.attachment,report_id:0
+#: field:poweremail.templates,report_template:0
+msgid "Report to send"
+msgstr "Informe a enviar"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Request Re-activation"
+msgstr "Solicitar reactivación"
+
+#. module: poweremail
+#: field:poweremail.templates,table_required_fields:0
+msgid "Required Fields"
+msgstr "Campos requeridos"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,smtpport:0
+msgid "SMTP Port "
+msgstr "Puerto SMTP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "SMTP SERVER or PORT not specified"
+msgstr "SERVIDOR SMTP o PUERTO no especificado"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "SMTP Server"
+msgstr "Servidor SMTP"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "SMTP Test Connection Was Successful"
+msgstr "El test de la conexión SMTP ha sido un éxito"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
+msgstr "Guardar cabecera -> Error al crear buzón. Cuenta: %s, Correo: %s, Error: %s"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
+msgstr "Guardar correo->Error al escribir en el buzón. Cuenta:%s, Correo:%s"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Save in Drafts"
+msgstr "Guardar en borradores"
+
+#. module: poweremail
+#: field:poweremail.preview,save_to_drafts_prev:0
+#: field:poweremail.templates,save_to_drafts:0
+msgid "Save to Drafts"
+msgstr "Guardar en borradores"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
+msgstr "Guardando cabecera de carga desconocida (%s). Cuenta: %s."
+
+#. module: poweremail
+#: field:poweremail.template.attachment,search_params:0
+msgid "Search params"
+msgstr "Parámetros de búsqueda"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Select Folder"
+msgstr "Seleccionar carpeta"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Select a folder before you save record"
+msgstr "Seleccione una carpeta antes de guardar el registro"
 
 #. module: poweremail
 #: help:poweremail.core_accounts,company:0
@@ -1088,38 +1902,197 @@ msgid ""
 msgstr "Indica si esta cuenta de correo electrónico no pertenece a un usuario específico, si no a la organización. Por ejemplo: info@dominio.com"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:461
+#: help:poweremail.templates,model_object_field:0
+msgid ""
+"Select the field from the model you want to use.\n"
+"If it is a relationship field you will be able to choose the nested values in the box below.\n"
+"(Note: If there are no values make sure you have selected the correct model)."
+msgstr "Seleccione el campo del modelo que quiera utilizar.\nSi es un campo de relación podrá escoger los valores relacionados en la opción inferior.\n(Nota: Si no hay valores asegúrese de escoger el modelo correcto)."
+
+#. module: poweremail
+#: help:poweremail.templates,table_model_object_field:0
+msgid ""
+"Select the field from the model you want to use.\n"
+"Only one2many & many2many fields can be used for tables."
+msgstr "Seleccione el campo del modelo que quiera utilizar.\nSólo los campos one2many y many2many se pueden utilizar para las tablas."
+
+#. module: poweremail
+#: help:poweremail.templates,table_required_fields:0
+msgid "Select the fields you require in the table."
+msgstr "Seleccione los campos que necesite en la tabla."
+
+#. module: poweremail
+#: help:poweremail.templates,auto_email:0
+msgid ""
+"Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
+"Note: Auto email can be enabled only after saving template."
+msgstr "Si selecciona correo electrónico automático se creará una acción de servidor para que se envíe un correo después de crearse/actualizarse un registro.\nAtención: Se puede activar el correo automático sólo después de guardar la plantilla."
+
+#. module: poweremail
+#: field:poweremail.templates,send_count:0
+msgid "Send Count"
+msgstr "Número de envíos"
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Send Email"
+msgstr "Enviar correo"
+
+#. module: poweremail
+#: field:poweremail.templates,send_immediately:0
+msgid "Send Immediately"
+msgstr "Enviar inmediatamente"
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Send Mail"
+msgstr "Enviar correo"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "Mail from Account %s failed. Probable Reason: Account not approved"
-msgstr "Correo desde la cuenta %s ha fallado. Motivo probable: Cuenta no aprobada."
+msgid "Send Mail (%s)"
+msgstr "Enviar correo (%s)"
 
 #. module: poweremail
-#: field:poweremail.templates,model_data_name:0
-msgid "Code"
-msgstr "Código"
+#: selection:poweremail.send.wizard,state:0
+msgid "Send Type"
+msgstr "Tipo de envío"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:710
+#: view:poweremail.send.wizard:0
+msgid "Send all mails"
+msgstr "Enviar todos los correos"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send mail Wizard"
+msgstr "Asistente de envío de correo"
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send now"
+msgstr "Enviar ahora"
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_create:0
+msgid "Send on Create"
+msgstr "Enviar al crear"
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_write:0
+msgid "Send on Update"
+msgstr "Enviar al actualizar"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Send/Receive"
+msgstr "Enviar/Recibir"
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
+#: selection:poweremail.mailbox,state:0
+msgid "Sending"
+msgstr "Enviando"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
 msgid ""
-"Datetime Extraction failed. Date: %s\n"
+"Sending mail from Account {} failed.\n"
+"Description: {}"
+msgstr "El envio de correo desde la cuenta {} ha fallado.\nDescripción: {}"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid ""
+"Sending of Mail %s failed. Probable Reason: Could not login to server\n"
 "Error: %s"
-msgstr "Extracción de fecha y hora ha fallado. Fecha: %s\nError: %s"
+msgstr "El envío del correo %s ha fallado. Probable razón: No se pudo conectar con el servidor\nError: %s"
 
 #. module: poweremail
-#: field:poweremail.templates,record_attachment_categories:0
-msgid "Record attachment categories"
-msgstr "Categorías de los adjuntos del registro"
+#: help:poweremail.templates,send_on_write:0
+msgid "Sends an e-mail when a document is modified."
+msgstr "Envía un correo electrónico cuando se modifica un documento."
 
 #. module: poweremail
-#: field:poweremail.templates,auto_email:0
-msgid "Auto Email"
-msgstr "Correo electrónico automático"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
+msgid "Sent"
+msgstr "Enviados"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,smtpport:0
-msgid "SMTP Port "
-msgstr "Puerto SMTP"
+#: field:poweremail.core_accounts,smtpserver:0
+msgid "Server"
+msgstr "Servidor"
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Server Information"
+msgstr "Información del servidor"
+
+#. module: poweremail
+#: field:poweremail.mailbox,server_ref:0
+msgid "Server Reference of mail"
+msgstr "Referencia del servidor de correo"
+
+#. module: poweremail
+#: field:poweremail.core_accounts,iserver_type:0
+msgid "Server Type"
+msgstr "Tipo de servidor"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
+msgid "Shows a list of IMAP folders"
+msgstr "Muestra la lista de carpetas IMAP"
+
+#. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid ""
+"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
+"els adjunts del registre utilitzat per renderitzar el email."
+msgstr "Si se marca esta opción, se enviarán como ficheros adjuntos del correo todos los adjuntos del registro indicado."
+
+#. module: poweremail
+#: selection:poweremail.send.wizard,state:0
+msgid "Simple Mail Wizard Step 1"
+msgstr "Asistente correo simple - Paso 1"
+
+#. module: poweremail
+#: field:poweremail.send.wizard,single_email:0
+#: field:poweremail.templates,single_email:0
+msgid "Single email"
+msgstr "Sólo un correo electrónico"
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_text:0
+#: field:poweremail.templates,def_body_text:0
+msgid "Standard Body (Text)"
+msgstr "Cuerpo del mensaje (texto)"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpssl:0
+msgid "Start a SMTP connection through SSL (Usually port 465)"
+msgstr "Establecer una conexión SMTP utilizando SSL (normalmente puerto 465)"
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtptls:0
+msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
+msgstr "Establecer una conexión TLS después de la conexión SMTP (normalmente puerto 587)"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Full mail reception for mail: %s."
+msgstr "Iniciando recepción completa de correos para correo: %s."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Header reception for account: %s."
+msgstr "Iniciando recepción de cabecera para la cuenta: %s."
 
 #. module: poweremail
 #: field:poweremail.preview,state:0 field:wizard.change.folder.email,state:0
@@ -1128,274 +2101,59 @@ msgid "State"
 msgstr "Estado"
 
 #. module: poweremail
-#: help:poweremail.templates,copyvalue:0
-msgid ""
-"Copy and paste the value in the location you want to use a system value."
-msgstr "Copie y pegue el valor en la ubicación que quiera utilizar un valor del sistema."
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Plain Text"
-msgstr "Texto plano"
-
-#. module: poweremail
-#: field:poweremail.templates,ref_ir_value:0
-msgid "Wizard Button"
-msgstr "Botón asistente"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "Mail fetch exception"
-msgstr "Excepción de extracción de correo"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
-msgstr "Introduzca el número del puerto, por ejemplo para SMTP el 587."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1376
-#, python-format
-msgid "%s Mail Form"
-msgstr "%s formulario de correo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1050
-#, python-format
-msgid "Starting Full mail reception for mail: %s."
-msgstr "Iniciando recepción completa de correos para correo: %s."
-
-#. module: poweremail
-#: view:poweremail.preview:0 field:poweremail.preview,env:0
-msgid "Extra scope variables"
-msgstr "Variables extra del ámbito (scope) "
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#, python-format
-msgid ""
-"No personal email accounts are configured for you. \n"
-"Either ask admin to enforce an account for this template or get yourself a personal power email account."
-msgstr "No se han configurado cuentas de correo personales para usted.\nSolicite al administrador que le proporcione una cuenta para esta plantilla o obtenga usted mismo una cuenta de correo personal de poweremail."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1078
-#, python-format
-msgid "IMAP Folder selected successfully Account: %s."
-msgstr "Carpeta IMAP seleccionada correctamente. Cuenta: %s."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
-msgid "Emails to sent"
-msgstr "Correos a enviar"
+#: view:poweremail.templates:0
+msgid "Static attachments"
+msgstr "Adjuntos estáticos"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "o - current object"
-msgstr "o - objeto actual"
+msgid "Stats"
+msgstr "Estadísticas"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,isfolder:0 field:poweremail.mailbox,folder:0
-#: field:wizard.change.folder.email,folder:0
-msgid "Folder"
-msgstr "Carpeta"
+#: field:poweremail.templates,stats_interval:0
+msgid "Stats Interval"
+msgstr "Intervalo de estadísticas"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
-msgid "Trash"
-msgstr "Papelera"
+#: field:poweremail.mailbox,state:0 field:poweremail.send.wizard,state:0
+msgid "Status"
+msgstr "Estado"
 
 #. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar correos relacionados"
-msgstr "Buscar correos relacionados"
+#: field:poweremail.templates,sub_model_object_field:0
+msgid "Sub Field"
+msgstr "Sub-campo"
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Attachment settings"
-msgstr "Configuración del adjunto"
+#: field:poweremail.templates,sub_object:0
+msgid "Sub-model"
+msgstr "Sub-modelo"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1267
-#: code:addons/poweremail/poweremail_core.py:1270
-#, python-format
-msgid "IMAP Server Folder Error"
-msgstr "Error carpeta servidor IMAP"
+#: field:poweremail.preview,subject:0 field:poweremail.send.wizard,subject:0
+msgid "Subject"
+msgstr "Asunto"
 
 #. module: poweremail
-#: field:poweremail.templates,partner_event:0
-msgid "Partner ID to log Events"
-msgstr "ID empresa para registrar eventos"
+#: view:poweremail.core_accounts:0
+msgid "Suspend Account"
+msgstr "Suspender cuenta"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:405
-#, python-format
-msgid "Incoming server password is not defined"
-msgstr "No se ha definido la contraseña del servidor de entrada"
+#: selection:poweremail.core_accounts,state:0
+msgid "Suspended"
+msgstr "Suspendida"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:399
-#, python-format
-msgid "Incoming server is not defined"
-msgstr "No se ha definido el servidor de entrada"
+#: field:poweremail.templates,table_model_object_field:0
+msgid "Table Field"
+msgstr "Campo de la tabla"
 
 #. module: poweremail
-#: field:poweremail.templates,null_value:0
-msgid "Null Value"
-msgstr "Valor nulo"
-
-#. module: poweremail
-#: field:poweremail.templates,template_language:0
-msgid "Templating Language"
-msgstr "Idioma de la plantilla"
-
-#. module: poweremail
-#: field:poweremail.conversation,name:0
-msgid "Name"
-msgstr "Nombre"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Trash"
-msgstr "Papelera"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
-msgid "Personal Accounts"
-msgstr "Cuentas personales"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Sent"
-msgstr "Enviado"
-
-#. module: poweremail
-#: help:poweremail.templates,table_html:0
-msgid ""
-"Copy this html code to your HTML message body for displaying the info in "
-"your mail."
-msgstr "Copie este código HTML en el cuerpo del mensaje HTML para mostrar la información en su correo electrónico."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:296
-#, python-format
-msgid "Core connection for the given ID does not exist"
-msgstr "La conexión básica para el ID dado no existe"
-
-#. module: poweremail
-#: help:poweremail.templates,server_action:0
-msgid "Corresponding server action is here."
-msgstr "La acción correspondiente de servidor está aquí."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "cr - database cursor"
-msgstr "cr - cursor BBDD"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
-#: view:wizard.send.email:0
-msgid "Enviar emails"
-msgstr "Enviar correos"
-
-#. module: poweremail
-#: view:poweremail.templates:0 field:poweremail.templates,filter:0
-msgid "Filter"
-msgstr "Filtro"
-
-#. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
-msgid "Reenviar emails amb error"
-msgstr "Reenviar correos con error"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1154
-#, python-format
-msgid ""
-"Incoming server login attempt dropped Account: %s\n"
-"Check if Incoming server attributes are complete."
-msgstr "Intento de autenticación con el servidor de entrada abortado. Cuenta:%s.\nComprueba si los datos del servidor de entrada están completos."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_template_emails
-msgid "Template emails"
-msgstr "Plantillas de correo"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
-msgid "IMAP Folder Selection Wizard"
-msgstr "Asistente selección carpeta IMAP"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "High"
-msgstr "Alta"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1072
-#, python-format
-msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
-msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:224
-#, python-format
-msgid "The email must have a sending account."
-msgstr "El correo debe tener una cuenta de envío."
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Simple Mail Wizard Step 1"
-msgstr "Asistente correo simple - Paso 1"
-
-#. module: poweremail
-#: field:poweremail.templates,attach_record_items:0
-msgid "Attach record items"
-msgstr "Adjuntar elementos"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:62
-#, python-format
-msgid "Error receiving mail: %s"
-msgstr "Error recibiendo correo: %s"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Create send email wizard"
-msgstr "Crear asistente de envío de correo"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send mail Wizard"
-msgstr "Asistente enviar correo"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Power Email Templates"
-msgstr "Plantillas de correo electrónico"
-
-#. module: poweremail
-#: view:wizard.change.folder.email:0
-msgid "Emails canviats de carpeta!"
-msgstr "Correos cambiados de buzón!"
-
-#. module: poweremail
-#: help:poweremail.templates,record_attachment_categories:0
-msgid ""
-"Only attach record attachments with the included categories in case there's "
-"any."
-msgstr "Adjuntar únicamente adjuntos del registro con las categorías incluidas en el caso de que haya alguna"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:311
-#, python-format
-msgid "Error sending email with id {}: {}"
-msgstr "Error enviando el correo con id {}: {}"
+#: field:poweremail.templates,table_sub_object:0
+msgid "Table-model"
+msgstr "Modelo-Tabla"
 
 #. module: poweremail
 #: field:ir.actions.server,poweremail_template:0
@@ -1406,304 +2164,91 @@ msgid "Template"
 msgstr "Plantilla"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,smtpserver:0
-msgid "Enter name of outgoing server, eg: smtp.gmail.com"
-msgstr "Escriba el nombre del servidor de correo de salida, por ejemplo: smtp.gmail.com"
+#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
+msgid "Template Preview"
+msgstr "Vista previa de la plantilla"
 
 #. module: poweremail
-#: view:poweremail.preview:0
-msgid "Power Email Preview"
-msgstr "Previsualización"
+#: model:ir.actions.act_window,name:poweremail.action_template_emails
+msgid "Template emails"
+msgstr "Plantillas de correo"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:990
-#, python-format
-msgid "Error evaluating the expression in 'Reference of the report' field: %s"
-msgstr "Error al evaluar la expresión en el campo 'Referencia del informe': %s"
+#: field:poweremail.preview,model_ref:0
+msgid "Template reference"
+msgstr "Referencia de la plantilla"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:532
-#, python-format
-msgid "Email will be sent again"
-msgstr "El correo se volverá a enviar"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
+msgid "Templates"
+msgstr "Plantillas"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
-msgstr "Correo original"
+#: field:poweremail.templates,template_language:0
+msgid "Templating Language"
+msgstr "Idioma de la plantilla"
 
 #. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body HTML"
-msgstr "Cuerpo HTML"
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Text otherwise HTML"
+msgstr "Texto, en caso contrario HTML"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,iserver:0
-msgid "Enter name of incoming server, eg: imap.gmail.com"
-msgstr "Introduzca el nombre de servidor del correo de entrada, por ejemplo: imap.gmail.com"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1314
-#, python-format
-msgid "This is an invalid folder"
-msgstr "Esta carpeta no es válida"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
+#: constraint:ir.model:0
 msgid ""
-"Check it if you want to send a single email for several records (the "
-"optional attachment will be generated as a single file for all these r "
-"ecords). If you don't check it, an email with its optional attachment will "
-"be send for each record."
-msgstr "Seleccionelo si quiere enviar un único correo electrónico para los diversos registro (el adjunto opcional se genera como un único archivo para todos estos registros). Si no lo selecciona, se envía un correo electrónico con su adjunto opcional para cada registro."
+"The Object name must start with x_ and not contain any special character !"
+msgstr "¡El nombre del objeto debe empezar con x_ y no contener ningún carácter especial!"
 
 #. module: poweremail
-#: help:poweremail.core_accounts,email_id:0
-msgid "eg: yourname@yourdomain.com"
-msgstr "Ejemplo: sunombre@sudominio.com"
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "The body of the email must not be empty."
+msgstr "El contenido del correo no puede estar vacío"
 
 #. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
+#: help:poweremail.templates,def_bcc:0
+msgid "The default BCC for the email. Placeholders can be used here."
+msgstr "El BCC por defecto del correo electrónico. Se pueden usar expresiones de campos."
+
+#. module: poweremail
+#: help:poweremail.templates,def_cc:0
+msgid "The default CC for the email. Placeholders can be used here."
+msgstr "El CC por defecto del correo electrónico. Se pueden usar expresiones de campos."
+
+#. module: poweremail
+#: help:poweremail.templates,lang:0
 msgid ""
-"Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots "
-"els adjunts del registre utilitzat per renderitzar el email."
-msgstr "Si se marca esta opción, se enviarán como ficheros adjuntos del correo todos los adjuntos del registro indicado."
+"The default language for the email. Placeholders can be used here. eg. "
+"${object.partner_id.lang}"
+msgstr "El idioma por defecto del correo electrónico. Se pueden usar expresiones de campos, por ej. ${object.partner_id.lang}"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
-msgid "Mailbox: Sending"
-msgstr "Buzón: Enviando"
+#: help:poweremail.templates,def_to:0
+msgid "The default recepient of email. Placeholders can be used here."
+msgstr "El destinatario por defecto del correo electrónico. Se pueden usar expresiones de campos."
 
 #. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
-msgid "Demo email subject for user ${object.login}"
-msgstr "Asunto de correo de demostración para el usuario ${object.login}"
+#: help:poweremail.templates,def_subject:0
+msgid "The default subject of email. Placeholders can be used here."
+msgstr "El asunto por defecto del correo electrónico. Se pueden usar expresiones de campos."
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email All Emails"
-msgstr "Todos los correos"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
-msgstr "No descargar los adjuntos automáticamente"
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,folder:0
-msgid "IMAP Folder"
-msgstr "Carpeta IMAP"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Automatisms settings"
-msgstr "Configuración de la automatización"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isssl:0
-#: field:poweremail.core_accounts,smtpssl:0
-msgid "Use SSL"
-msgstr "Utilizar SSL"
-
-#. module: poweremail
-#: model:poweremail.templates,file_name:poweremail.default_template_poweremail_2
-msgid "${object.number}"
-msgstr "${object.number}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:456
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
 #, python-format
-msgid ""
-"Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
-"Error: %s"
-msgstr "El correo desde la cuenta %s ha fallado en la autenticación. Causa probable: No se puede autenticar al servidor\nError: %s"
+msgid "The email address is not valid."
+msgstr "La dirección del correo no es válida."
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Insert Simple Field"
-msgstr "Insertar campo simple"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
-msgid "Mailbox: Sent"
-msgstr "Buzón: Enviados"
-
-#. module: poweremail
-#: field:poweremail.mailbox,priority:0 field:poweremail.send.wizard,priority:0
-msgid "Priority"
-msgstr "Prioridad"
-
-#. module: poweremail
-#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail
-msgid ""
-"<!doctype html>\n"
-"<html>\n"
-"<head></head>\n"
-"<body>\n"
-"This is a demo email\n"
-"</body>\n"
-"</html>"
-msgstr "<!doctype html>\n<html>\n<head></head>\n<body>\nEste es un correo de demostración\n</body>\n</html>"
-
-#. module: poweremail
-#: help:poweremail.templates,send_on_create:0
-msgid ""
-"Create an e-mail when a new record is created. The instance where the record"
-" is created must be restarted for the changes to take effect."
-msgstr "Crear un correo electrónico cuando se cree un nuevo registro. La instancia en la que se crea el registro debe reiniciarse para que los cambios surtan efecto."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
-msgid "Email Basic Templates"
-msgstr "Plantillas de correo básicas"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:315
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "Out going connection test failed"
-msgstr "El test de la conexión de salida ha fallado"
+msgid "The email must have a destiny account."
+msgstr "El correo debe tener una cuenta de destino."
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
-msgid "Sent"
-msgstr "Enviados"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:416
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "The specified record for connection does not exist"
-msgstr "El registro especificado para la conexión no existe"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#, python-format
-msgid "Please specify an template to use for auto email in poweremail!"
-msgstr "¡Indique una plantilla para usar para los correos automáticos en poweremail!"
-
-#. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Mako Templates"
-msgstr "Plantillas Mako"
-
-#. module: poweremail
-#: field:poweremail.templates,def_priority:0
-msgid "Default priority"
-msgstr "Prioridad por defecto"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_send_email
-msgid "wizard.send.email"
-msgstr "wizard.send.email"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtptls:0
-msgid "Use TLS"
-msgstr "Utilizar TLS"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
-msgid "Mailbox: All emails"
-msgstr "Buzón: Todos los correos"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 view:poweremail.templates:0
-msgid "Advanced"
-msgstr "Avanzado"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
-#: selection:poweremail.mailbox,state:0
-msgid "Sending"
-msgstr "Enviando"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:959
-#, python-format
-msgid ""
-"IMAP Server Folder Selection Error Account: %s Error: %s.\n"
-"Check account settings if you have selected a folder."
-msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s.\nCompruebe si ha seleccionado una carpeta en la configuración de la cuenta."
-
-#. module: poweremail
-#: field:poweremail.core_accounts,state:0
-msgid "Account Status"
-msgstr "Estado de la cuenta"
-
-#. module: poweremail
-#: help:poweremail.preview,enforce_from_account:0
-msgid "Email will be sent from this account."
-msgstr "El correo se enviará desde esta cuenta."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1123
-#, python-format
-msgid "POP3 Server Error Account: %s Error: %s."
-msgstr "Error del servidor POP3 en la cuenta %s. Error: %s."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Select Folder"
-msgstr "Seleccionar carpeta"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:245
-#, python-format
-msgid "Email sent successfully"
-msgstr "Correo enviado correctamente"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtpserver:0
-msgid "Server"
-msgstr "Servidor"
-
-#. module: poweremail
-#: help:poweremail.templates,send_immediately:0
-msgid ""
-"Emails created from this template will be sent immediately without going "
-"through outbox folder."
-msgstr "Los correos creados a partir de esta plantilla se enviarán inmediatamente sin pasar por la carpeta de bandeja de salida."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:1061
-#, python-format
-msgid "IMAP Server Connected & logged in successfully Account: %s."
-msgstr "Servidor IMAP conectado y autenticado correctamente. Cuenta: %s."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1140
-#, python-format
-msgid "POP3 Server Connected & logged in successfully Account: %s."
-msgstr "Servidor POP3 conectado y autenticado correctamente. Cuenta: %s."
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Other settings"
-msgstr "Otras configuraciones"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_subject:0
-msgid " Subject"
-msgstr "Asunto"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Mail Details"
-msgstr "Detalle del correo electrónico"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:295
-#, python-format
-msgid "SMTP SERVER or PORT not specified"
-msgstr "SERVIDOR SMTP o PUERTO no especificado"
+msgid "The email must have a sending account."
+msgstr "El correo debe tener una cuenta de envío."
 
 #. module: poweremail
 #: view:poweremail.templates:0
@@ -1713,187 +2258,105 @@ msgid ""
 msgstr "El nombre del archivo debe seguir el formato: TEXTO.IDIOMA.EXTENSION (por ejemplo: reunión_extraordinaria.es_ES.pdf) para identificar el documento por idioma."
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Power Email Configuration"
-msgstr "Configuración"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "Yes"
-msgstr "Sí"
-
-#. module: poweremail
-#: field:poweremail.templates,send_immediately:0
-msgid "Send Immediately"
-msgstr "Enviar inmediatamente"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:396
-#, python-format
-msgid "From Poweremail Mailbox {} Original email as {}"
-msgstr "Desde el buzón {} correo original como {}"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:652
-#, python-format
+#: help:poweremail.templates,filter:0
 msgid ""
-"Sending mail from Account {} failed.\n"
-"Description: {}"
-msgstr "El envio de correo desde la cuenta {} ha fallado.\nDescripción: {}"
+"The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
+"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
+msgstr "El código python introducido aquí será ejecutado. Si el resultado es True el correo será enviado y si es False no se enviará.\nEjemplo : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:930
+#: help:poweremail.templates,use_sign:0
+msgid "The signature from the User details will be appened to the mail."
+msgstr "La firma del usuario (definida en sus preferencias) se añadirá al correo."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Downloaded & saved %s attachments Account: %s."
-msgstr "Descargados y guardados %s adjuntos. Cuenta: %s."
+msgid "The specified record for connection does not exist"
+msgstr "El registro especificado para la conexión no existe"
 
 #. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Low"
-msgstr "Baja"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
-msgid "My Account"
-msgstr "Mi cuenta"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Request Re-activation"
-msgstr "Solicitar reactivación"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1134
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "POP3 Server Login Error Account: %s Error: %s."
-msgstr "Error de autenticación servidor POP3. Cuenta: %s Error: %s."
+msgid "The template name must be unique!"
+msgstr "¡El nombre de la plantilla debe ser único!"
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Initiated"
-msgstr "Iniciada"
+#: help:poweremail.templates,def_body_html:0
+#: help:poweremail.templates,def_body_text:0
+msgid "The text version of the mail."
+msgstr "La versión texto del correo."
+
+#. module: poweremail
+#: help:poweremail.templates,null_value:0
+msgid "This Value is used if the field is empty."
+msgstr "Este valor se utiliza si el campo se encuentra vacío."
+
+#. module: poweremail
+#: help:poweremail.templates,table_sub_object:0
+msgid "This field shows the model you will be using for your table."
+msgstr "Este campo muestra el modelo que utilizará en su tabla."
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "This is an invalid folder"
+msgstr "Esta carpeta no es válida"
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_send_wizard
+msgid "This is the wizard for sending mail"
+msgstr "Este es el asistente para enviar correo electrónico"
+
+#. module: poweremail
+#: help:poweremail.templates,use_filter:0
+msgid ""
+"This option allow you to add a custom python filter before sending a mail"
+msgstr "This option allow you to add a custom python filter before sending a mail"
 
 #. module: poweremail
 #: view:poweremail.send.wizard:0
 msgid ""
 "Tip: Multiple emails are sent in the same language (the first one is "
 "proposed). We suggest you send emails in groups according to langu age."
-msgstr "Consejo: Los correos electrónicos múltiples se envían en el mismo idioma (se propone el primero de ellos). Le sugerimos que envíe los correos en grupos según el idioma."
+msgstr "Consejo: Los correos múltiples se envían en el mismo idioma (se propone el primero). Le recomendamos enviar los correos en grupos según el idioma."
 
 #. module: poweremail
-#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Cancel·lar"
-msgstr "Cancelar"
+#: field:poweremail.preview,to:0 field:poweremail.send.wizard,to:0
+msgid "To"
+msgstr "Para"
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
-msgid "Outbox"
-msgstr "Salida"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
+msgid "Trash"
+msgstr "Papelera"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_message_id:0
-msgid "Message-Id"
-msgstr "Message-Id"
+#: selection:poweremail.mailbox,state:0
+msgid "Un-Read"
+msgstr "Sin leer"
 
 #. module: poweremail
-#: field:poweremail.preview,model_ref:0
-msgid "Template reference"
-msgstr "Referencia de la plantilla"
+#: field:poweremail.core_accounts,isssl:0
+#: field:poweremail.core_accounts,smtpssl:0
+msgid "Use SSL"
+msgstr "Utilizar SSL"
 
 #. module: poweremail
-#: field:poweremail.preview,cc:0 field:poweremail.send.wizard,cc:0
-msgid "CC"
-msgstr "CC"
+#: field:poweremail.templates,use_sign:0
+msgid "Use Signature"
+msgstr "Utiliza la firma"
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Send Mail"
-msgstr "Enviar correo"
+#: field:poweremail.core_accounts,smtptls:0
+msgid "Use TLS"
+msgstr "Utilizar TLS"
 
 #. module: poweremail
-#: field:poweremail.templates,report_template_object_reference:0
-msgid "Reference of the report"
-msgstr "Referencia del informe"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_change_folder_email_form
-#: view:wizard.change.folder.email:0
-msgid "Canviar emails de carpeta"
-msgstr "Cambiar correos de buzón"
-
-#. module: poweremail
-#: view:ir.actions.server:0
-msgid "Email Configuration"
-msgstr "Configuración correo electrónico"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:242
-#, python-format
-msgid "An error occurred while rendering template id {}:  {}"
-msgstr "Ha ocurrido un error mientras se renderizaba la plantilla con id {}:  {}"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
-msgid "Mailbox: Error"
-msgstr "Buzón: Error"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0 field:poweremail.mailbox,pem_attachments_ids:0
-#: view:poweremail.send.wizard:0 field:poweremail.send.wizard,attachment_ids:0
-#: view:poweremail.template.attachment:0
-#: field:poweremail.templates,ir_attachment_ids:0
-#: field:poweremail.templates,tmpl_attachment_ids:0
-msgid "Attachments"
-msgstr "Adjuntos"
-
-#. module: poweremail
-#: field:poweremail.templates,model_object_field:0
-msgid "Field"
-msgstr "Campo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:753
-#, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
-msgstr "Guardando cabecera de carga desconocida (%s). Cuenta: %s."
-
-#. module: poweremail
-#: help:poweremail.templates,enforce_from_account:0
-msgid "Emails will be sent only from this account."
-msgstr "Los correos electrónicos se enviaran sólo desde esta cuenta."
-
-#. module: poweremail
-#: constraint:ir.model:0
-msgid ""
-"The Object name must start with x_ and not contain any special character !"
-msgstr "¡El nombre del objeto debe empezar con x_ y no contener ningún carácter especial!"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid ""
-"After clicking send all mails, mails will be sent to outbox and cleared in "
-"next Send/Recieve"
-msgstr "Después de hacer clic en Enviar ahora, los correos se colocarán en el buzón de salida. Los correos se enviarán en el siguiente Enviar/Recibir (manual o automático) de su bandeja de salida."
-
-#. module: poweremail
-#: field:poweremail.core_accounts,allowed_groups:0 view:poweremail.templates:0
-#: field:poweremail.templates,allowed_groups:0
-msgid "Allowed User Groups"
-msgstr "Grupos de usuarios permitidos"
-
-#. module: poweremail
-#: selection:poweremail.preview,state:0
-#: selection:wizard.change.folder.email,state:0
-#: selection:wizard.change.state.email,wiz_state:0
-#: selection:wizard.send.email,state:0
-msgid "Init"
-msgstr "Init"
+#: field:poweremail.mailbox,pem_user:0
+msgid "User"
+msgstr "Usuario"
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
@@ -1901,21 +2364,28 @@ msgid "User Information"
 msgstr "Información del usuario"
 
 #. module: poweremail
-#: view:wizard.send.email:0
-msgid "Emails enviats!"
-msgstr "Correos enviados!"
+#: field:poweremail.core_accounts,isuser:0
+#: field:poweremail.core_accounts,smtpuname:0
+msgid "User Name"
+msgstr "Nombre de usuario"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:214
+#: field:poweremail.mailbox,pem_account_id:0
+msgid "User account"
+msgstr "Cuenta usuario"
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "The body of the email must not be empty."
-msgstr "El contenido del correo no puede estar vacío"
+msgid "Warning"
+msgstr "Aviso"
 
 #. module: poweremail
-#: view:wizard.change.folder.email:0 view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Endavant"
-msgstr "Adelante"
+#: help:poweremail.templates,sub_object:0
+msgid ""
+"When a relation field is used this field will show you the type of field you"
+" have selected."
+msgstr "Cuando se utiliza un campo de relación, este campo mostrará el tipo de campo que ha seleccionado."
 
 #. module: poweremail
 #: help:poweremail.preview,save_to_drafts_prev:0
@@ -1926,346 +2396,6 @@ msgid ""
 msgstr "Cuando se envian correos electrónico generados automáticamentes a partir de esta plantilla, se guardan en la carpeta Borradores en lugar de enviarlos inmediatamente."
 
 #. module: poweremail
-#: help:poweremail.templates,partner_event:0
-msgid ""
-"Partner ID who an email event is logged.\n"
-"Placeholders can be used here. eg. ${object.partner_id.id}\n"
-"You must install the mail_gateway module to see the mail events in partner form.\n"
-"If you also want to record the link to the object that sends the email, you must to add this object in the 'Administration/Low Level Objects/Requests/Accepted Links in Requests' menu (or 'ir.attachment' to record the attachments)."
-msgstr "ID de empresa donde debe registrarse un evento de correo.\nSe pueden usar expresiones de campos. Por ej. ${object.partner_id.id}\nDebe instalar el módulo mail_gateway para ver los eventos de correo en el formulario de empresa.\nSi también desea guardar el enlace hacia el objeto que envía el correo, debe añadir este objeto en el menú 'Administración/Personalización/Objetos de bajo nivel/Solicitudes/Tipos de referencias en solicitudes' (o 'ir.attachment' para guardar los adjuntos)."
-
-#. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:183
-#, python-format
-msgid "Generated Email"
-msgstr "Correo generado"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Expression builder"
-msgstr "Generador de expresiones"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_accounts
-msgid "poweremail.core_accounts"
-msgstr "poweremail.cuentas_básicas"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Text otherwise HTML"
-msgstr "Texto, en caso contrario HTML"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0 view:poweremail.templates:0
-msgid "Body (HTML)"
-msgstr "Cuerpo del mensaje (HTML)"
-
-#. module: poweremail
-#: field:poweremail.templates,attached_activity:0
-msgid "Activity"
-msgstr "Actividad"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Remove send email wizard"
-msgstr "Eliminar asistente de envío de correo"
-
-#. module: poweremail
-#: view:wizard.change.state.email:0
-msgid "Emails canviats d'estat!"
-msgstr "Estado de los correos cambiado!"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:901
-#, python-format
-msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
-msgstr "Guardar correo->Error al escribir en el buzón. Cuenta:%s, Correo:%s"
-
-#. module: poweremail
-#: field:poweremail.templates,enforce_from_account:0
-msgid "Enforce From Account"
-msgstr "Fuerza desde la cuenta"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Dynamic attachments (reports)"
-msgstr "Adjuntos dinámicos (informes)"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,send_pref:0
-msgid "Mail Format"
-msgstr "Formato del correo electrónico"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "uid - current user ID"
-msgstr "uid - ID usuari actual"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isport:0
-msgid "Port"
-msgstr "Puerto"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#, python-format
-msgid "Emails for multiple items saved in outbox."
-msgstr "Correos para múltiples elementos guardados en el buzón de salida."
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_create:0
-msgid "Send on Create"
-msgstr "Enviar al crear"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Plain Text & HTML with no attachments"
-msgstr "Texto plano y HTML sin adjunto"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
-#, python-format
-msgid "Deletion of Record failed"
-msgstr "La eliminación del registro ha fallado"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:342
-#, python-format
-msgid "IMAP Server Error: {}"
-msgstr "Error del servidor IMAP: {}"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
-msgid "Company"
-msgstr "Compañía"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:767
-#: code:addons/poweremail/poweremail_core.py:838
-#, python-format
-msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
-msgstr "Guardar cabecera -> Error al crear buzón. Cuenta: %s, Correo: %s, Error: %s"
-
-#. module: poweremail
-#: field:poweremail.mailbox,create_date:0
-msgid "Created date"
-msgstr "Fecha de creación"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Approved"
-msgstr "Aprobada"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:219
-#, python-format
-msgid "The email must have a destiny account."
-msgstr "El correo debe tener una cuenta de destino."
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:373
-#, python-format
-msgid ""
-"Programming Error in _get_pop3_server method. The record received is "
-"invalid."
-msgstr "Error de programación en el método _get_pop3_server. El registro que se ha recibido no es valido."
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Ok"
-msgstr "Aceptar"
-
-#. module: poweremail
-#: field:poweremail.template.attachment,file_name:0
-msgid "File name"
-msgstr "Nombre del fichero"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_recd:0
-msgid "Received at"
-msgstr "Recibido el"
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,name:0
-msgid "Email Account"
-msgstr "Cuenta de correo electrónico"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1011
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s"
-msgstr "Estadísticas POP3: %s correos de tamaño %s para la cuenta: %s"
-
-#. module: poweremail
-#: field:poweremail.preview,bcc:0 field:poweremail.send.wizard,bcc:0
-msgid "BCC"
-msgstr "BCC"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,email_id:0
-msgid "Email ID"
-msgstr "ID correo electrónico"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,full_success:0
-msgid "Complete Success"
-msgstr "El proceso se ha realizado correctamente"
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "OK"
-msgstr "Aceptar"
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_change_folder_email
-msgid "wizard.change.folder.email"
-msgstr "wizard.change.folder.email"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Download Full Mail"
-msgstr "Descargar todo el correo"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Both HTML & Text"
-msgstr "A la vez HTML y Texto"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
-#, python-format
-msgid "Warning"
-msgstr "Aviso"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
-msgid "Follow-up"
-msgstr "Seguimiento"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "security"
-msgstr "seguridad"
-
-#. module: poweremail
-#: field:poweremail.templates,ref_ir_act_window:0
-msgid "Window Action"
-msgstr "Acción de ventana"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Wizard send email"
-msgstr "Asistente de envío de correo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "No information on which mail should be fetched fully"
-msgstr "No existe información sobre que correo debería ser extraído completamente"
-
-#. module: poweremail
-#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
-msgid ""
-"\n"
-"\n"
-"<!doctype html>\n"
-"<html>\n"
-"<head></head>\n"
-"<body>\n"
-"Benvolgut/da ${object.login},\n"
-"\n"
-"Això és un email generic de prova per les poweremail_camapign.\n"
-"\n"
-"\n"
-"Atentament,\n"
-"\n"
-"un mort de gana.\n"
-"</body>\n"
-"</html>\n"
-"\n"
-"\t\t\t"
-msgstr "\n\n<!doctype html>\n<html>\n<head></head>\n<body>\nEstimado/da ${object.login},\n\nEsto es un correo genérico de prueba para las campañas de poweremail\n\n\nAtentamente,\n\nGISCE.\n</body>\n</html>\n\n\t\t\t"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Error"
-msgstr "Error de Power Email"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_body_html:0
-#: field:poweremail.templates,def_body_html:0
-msgid "Body (Text-Web Client Only)"
-msgstr "Cuerpo del mensaje (Texto - sólo cliente web)"
-
-#. module: poweremail
-#: field:wizard.change.state.email,estat:0
-msgid "Estat"
-msgstr "Estado"
-
-#. module: poweremail
-#: help:poweremail.templates,table_required_fields:0
-msgid "Select the fields you require in the table."
-msgstr "Seleccione los campos que necesite en la tabla."
-
-#. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
-msgstr "Plantilla Django"
-
-#. module: poweremail
-#: help:poweremail.templates,def_priority:0
-msgid "Default priority for auto generated emails"
-msgstr "Prioridad por defecto para los correos generados automáticamente"
-
-#. module: poweremail
-#: field:poweremail.templates,use_sign:0
-msgid "Use Signature"
-msgstr "Utiliza la firma"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_account_id:0
-msgid "User account"
-msgstr "Cuenta usuario"
-
-#. module: poweremail
-#: field:poweremail.send.wizard,signature:0
-msgid "Attach my signature to mail"
-msgstr "Añadir mi firma al correo"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:438
-#, python-format
-msgid "Incoming Test Connection Was Successful"
-msgstr "El test de la conexión de entrada ha sido un éxito"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
-msgid "Emails sent today"
-msgstr "Correos enviados hoy"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
-msgid "Configuration"
-msgstr "Configuración"
-
-#. module: poweremail
-#: constraint:ir.cron:0
-msgid "Invalid arguments"
-msgstr "Invalid arguments"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "HTML Body"
-msgstr "Cuerpo del mensaje HTML"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:435
-#, python-format
-msgid "In coming connection test failed"
-msgstr "El test de la conexión de entrada ha fallado"
-
-#. module: poweremail
 #: help:poweremail.templates,sub_model_object_field:0
 msgid ""
 "When you choose relationship fields this field will specify the sub value "
@@ -2273,162 +2403,89 @@ msgid ""
 msgstr "Cuando seleccione campos de relación, este campo indicará el sub-valor que puede utilizar."
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Body (Text)"
-msgstr "Cuerpo del mensaje (Texto)"
+#: field:poweremail.templates,ref_ir_act_window:0
+msgid "Window Action"
+msgstr "Acción de ventana"
 
 #. module: poweremail
-#: field:poweremail.template.attachment,report_id:0
-#: field:poweremail.templates,report_template:0
-msgid "Report to send"
-msgstr "Informe a enviar"
+#: field:poweremail.templates,ref_ir_value:0
+msgid "Wizard Button"
+msgstr "Botón asistente"
 
 #. module: poweremail
 #: selection:poweremail.send.wizard,state:0
-msgid "Multiple Mail Wizard Step 1"
-msgstr "Asistente correo múltiple - Paso 1"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "HTML otherwise Text"
-msgstr "HTML, en caso contrario Texto"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,user:0
-msgid "Related User"
-msgstr "Usuario relacionado"
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "No"
-msgstr "No"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
-msgid "Emails in error folder"
-msgstr "Correos en la carpeta de errores"
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Preview Email"
-msgstr "Vista previa del correo"
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_from:0
-msgid "From"
-msgstr "Desde"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:996
-#, python-format
-msgid ""
-"The expression in 'Reference of the report' field returned an empty value or"
-" a value that is not an integer ID."
-msgstr "La expresión en el campo 'Referencia del informe' devolvió un valor vacío o un valor que no es un ID entero."
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Suspend Account"
-msgstr "Suspender cuenta"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Normal"
-msgstr "Normal"
+msgid "Wizard Complete"
+msgstr "Asistente completo"
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Available global variables:"
-msgstr "Variables globales disponibles:"
+msgid "Wizard send email"
+msgstr "Asistente de envío de correo"
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
-msgid "Email Templates"
-msgstr "Plantillas de correo electrónico"
+#: field:poweremail.templates,attached_wkf:0
+msgid "Workflow"
+msgstr "Flujo de trabajo"
 
 #. module: poweremail
-#: field:poweremail.templates,sub_model_object_field:0
-msgid "Sub Field"
-msgstr "Sub-campo"
+#: selection:poweremail.core_accounts,company:0
+msgid "Yes"
+msgstr "Sí"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_user:0
-msgid "User"
-msgstr "Usuario"
+#: view:poweremail.templates:0
+msgid "context - current context"
+msgstr "context - contexto actual"
 
 #. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
-msgid "Factura ${object.number}"
-msgstr "Factura ${object.number}"
+#: view:poweremail.templates:0
+msgid "cr - database cursor"
+msgstr "cr - cursor BBDD"
 
 #. module: poweremail
-#: field:poweremail.mailbox,write_date:0
-msgid "Date modified"
-msgstr "Fecha de moodificación"
+#: help:poweremail.core_accounts,email_id:0
+msgid "eg: yourname@yourdomain.com"
+msgstr "Ejemplo: sunombre@sudominio.com"
 
 #. module: poweremail
-#: field:poweremail.templates,file_name:0
-msgid "File Name Pattern"
-msgstr "Patrón nombre de fichero"
+#: view:poweremail.templates:0
+msgid "o - current object"
+msgstr "o - objeto actual"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1397
-#: code:addons/poweremail/poweremail_template.py:1411
-#, python-format
-msgid "Send Mail (%s)"
-msgstr "Enviar correo (%s)"
+#: model:ir.model,name:poweremail.model_poweremail_core_accounts
+msgid "poweremail.core_accounts"
+msgstr "poweremail.cuentas_básicas"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:213
-#: code:addons/poweremail/poweremail_mailbox.py:218
-#: code:addons/poweremail/poweremail_mailbox.py:223
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#: code:addons/poweremail/poweremail_template.py:989
-#: code:addons/poweremail/poweremail_template.py:995
-#: code:addons/poweremail/poweremail_template.py:1017
-#: code:addons/poweremail/poweremail_template.py:1026
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:153
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
-#: selection:poweremail.preview,state:0
-#, python-format
-msgid "Error"
-msgstr "Error"
+#: model:ir.model,name:poweremail.model_poweremail_template_attachment
+msgid "poweremail.template.attachment"
+msgstr "poweremail.template.attachment"
 
 #. module: poweremail
-#: field:poweremail.core_accounts,iserver:0
-msgid "Incoming Server"
-msgstr "Servidor de entrada"
+#: view:poweremail.core_accounts:0
+msgid "security"
+msgstr "seguridad"
 
 #. module: poweremail
-#: help:poweremail.templates,table_model_object_field:0
-msgid ""
-"Select the field from the model you want to use.\n"
-"Only one2many & many2many fields can be used for tables."
-msgstr "Seleccione el campo del modelo que quiera utilizar.\nSólo los campos one2many y many2many se pueden utilizar para las tablas."
+#: view:poweremail.templates:0
+msgid "self - objects pointer"
+msgstr "self - puntero al objecto"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1027
-#, python-format
-msgid ""
-"No records found evaluating the expression in 'Reference of the report' "
-"field."
-msgstr "No se encontraron registros al evaluar la expresión en el campo 'Referencia del informe'."
+#: view:poweremail.templates:0
+msgid "uid - current user ID"
+msgstr "uid - ID usuari actual"
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:70
-#, python-format
-msgid "Django templates not installed"
-msgstr "Las plantillas Django no están instaladas"
+#: field:poweremail.conversation,from_abstract:0
+msgid "unknown"
+msgstr "desconocido"
 
 #. module: poweremail
-#: view:poweremail.conversation:0
-msgid "Power Email Conversation"
-msgstr "Conversación"
+#: model:ir.model,name:poweremail.model_wizard_change_folder_email
+msgid "wizard.change.folder.email"
+msgstr "wizard.change.folder.email"
 
 #. module: poweremail
 #: model:ir.model,name:poweremail.model_wizard_change_state_email
@@ -2436,160 +2493,11 @@ msgid "wizard.change.state.email"
 msgstr "wizard.change.state.email"
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_cc:0
-msgid " CC"
-msgstr " CC"
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
+msgstr "wizard.emails.generats.model"
 
 #. module: poweremail
-#: help:poweremail.templates,def_body_html:0
-#: help:poweremail.templates,def_body_text:0
-msgid "The text version of the mail."
-msgstr "La versión texto del correo."
-
-#. module: poweremail
-#: help:poweremail.templates,use_sign:0
-msgid "The signature from the User details will be appened to the mail."
-msgstr "La firma del usuario (definida en sus preferencias) se añadirá al correo."
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Close"
-msgstr "Cerrar"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:69
-#, python-format
-msgid "Error sending mail: %s"
-msgstr "Error enviando correo: %s"
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Llistar correus relacionats"
-msgstr "Listar correos relacionados"
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Check Incoming Connection"
-msgstr "Comprobar la conexión de entrada"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
-msgid "Personal"
-msgstr "Personal"
-
-#. module: poweremail
-#: field:poweremail.preview,to:0 field:poweremail.send.wizard,to:0
-msgid "To"
-msgstr "Para"
-
-#. module: poweremail
-#: help:poweremail.core_accounts,isport:0
-msgid "For example IMAP: 993,POP3:995"
-msgstr "Por ejemplo IMAP: 993, POP3: 995."
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
-#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
-msgid "Buscar Correus Relacionats"
-msgstr "Buscar Correos Relacionados"
-
-#. module: poweremail
-#: help:poweremail.templates,def_bcc:0
-msgid "The default BCC for the email. Placeholders can be used here."
-msgstr "El BCC por defecto del correo electrónico. Se pueden usar expresiones de campos."
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
-msgid "Templates"
-msgstr "Plantillas"
-
-#. module: poweremail
-#: help:poweremail.templates,def_subject:0
-msgid "The default subject of email. Placeholders can be used here."
-msgstr "El asunto por defecto del correo electrónico. Se pueden usar expresiones de campos."
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Read"
-msgstr "Leído"
-
-#. module: poweremail
-#: help:poweremail.templates,inline:0
-msgid "If the option is checked, the CSS will be inlined inside the HTML"
-msgstr "Si se marca la opción, el CSS se incrustará en los atributos de los elementos HTML"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,rec_headers_den_mail:0
-msgid "First Receive headers, then download mail"
-msgstr "Primero se descargan los encabezados, después el correo"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Insert Table"
-msgstr "Insertar tabla"
-
-#. module: poweremail
-#: field:poweremail.core_accounts,ispass:0
-#: field:poweremail.core_accounts,smtppass:0
-msgid "Password"
-msgstr "Contraseña"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:946
-#, python-format
-msgid "Starting Header reception for account: %s."
-msgstr "Iniciando recepción de cabecera para la cuenta: %s."
-
-#. module: poweremail
-#: field:poweremail.preview,report:0
-msgid "Report Name"
-msgstr "Nombre informe"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
-msgid "Template Preview"
-msgstr "Previsualización de la plantilla"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
-#: view:wizard.change.state.email:0
-msgid "Canviar estat dels emails"
-msgstr "Cambiar el estado de los correos"
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "OpenObject Code Filter:"
-msgstr "Filtro de código OpenObject:"
-
-#. module: poweremail
-#: field:poweremail.templates,def_subject:0
-msgid "Default Subject"
-msgstr "Asunto por defecto"
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
-msgid "Company Accounts"
-msgstr "Cuentas de la compañía"
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
-msgid "Inbox"
-msgstr "Entrada"
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Has Attachments"
-msgstr "Tiene adjuntos"
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Inbox"
-msgstr "Entrada"
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:958
-#, python-format
-msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
-msgstr "Error selección carpeta servidor IMAP. Cuenta: %s Error: %s."
+#: model:ir.model,name:poweremail.model_wizard_send_email
+msgid "wizard.send.email"
+msgstr "wizard.send.email"

--- a/i18n/poweremail.pot
+++ b/i18n/poweremail.pot
@@ -1,214 +1,23 @@
-# Translation of OpenERP Server.
-# This file contains the translation of the following modules:
-#	* poweremail
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: OpenERP Server 5.0.14\n"
-"Report-Msgid-Bugs-To: support@openerp.com\n"
-"POT-Creation-Date: 2026-03-20 11:21\n"
-"PO-Revision-Date: 2026-03-20 11:21\n"
-"Last-Translator: <>\n"
-"Language-Team: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
-
 #. module: poweremail
-#: help:poweremail.templates,send_immediately:0
-msgid "Emails created from this template will be sent immediately without going throug outbox folder."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
-msgid "Shows a list of IMAP folders"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,def_bcc:0
-msgid "Default BCC"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,model_object_field:0
-msgid "Select the field from the model you want to use.\n"
-"If it is a relationship field you will be able to choose the nested values in the box below.\n"
-"(Note: If there are no values make sure you have selected the correct model)."
-msgstr ""
-
-#. module: poweremail
-#: constraint:ir.actions.act_window:0
-msgid "Invalid model name in the action definition."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid " "
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,attached_wkf:0
-msgid "Workflow"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,single_email:0
-#: field:poweremail.templates,single_email:0
-msgid "Single email"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:904
-#, python-format
-msgid "Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
-msgid "Personal Account"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,server_ref:0
-msgid "Server Reference of mail"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
-msgid "My Accounts"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Incoming"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#, python-format
-msgid "Sending of Mail %s failed. Probable Reason: Could not login to server\n"
-"Error: %s"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Un-Read"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:576
-#, python-format
-msgid "The template name must be unique!"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,conversation_id:0
-msgid "Conversation"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:336
-#: code:addons/poweremail/poweremail_send_wizard.py:368
-#, python-format
-msgid "No Description"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Note: HTML body can't be edited with GTK desktop client."
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Wizard Complete"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,state:0
-msgid "Not Applicable"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
-msgid "Mailbox: Drafts"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.module.module,shortdesc:poweremail.module_meta_information
-msgid "Powerful Email capabilities for Open ERP"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,inline:0
-msgid "Inline HTML"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:56
-#, python-format
-msgid "Mako templates not installed"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,requested:0
-msgid "No of requested Mails"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "POP3"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,model_data_name:0
-msgid "Model Data Name."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Stats"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,null_value:0
-msgid "This Value is used if the field is empty."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Send/Receive"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
-msgid "MailBox"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpssl:0
-msgid "Start a SMTP connection through SSL (Usually port 465)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,table_sub_object:0
-msgid "Table-model"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "self - objects pointer"
-msgstr ""
-
-#. module: poweremail
-#: view:ir.actions.server:0
-msgid "All values for the mail can be configured in the template editor itself."
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,stats_interval:0
-msgid "Number of days used to calculate the send count backwards from today. If empty or zero, all sent emails are taken into account."
+#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
+msgid "\n"
+"\n"
+"<!doctype html>\n"
+"<html>\n"
+"<head></head>\n"
+"<body>\n"
+"Benvolgut/da ${object.login},\n"
+"\n"
+"Això és un email generic de prova per les poweremail_camapign.\n"
+"\n"
+"\n"
+"Atentament,\n"
+"\n"
+"un mort de gana.\n"
+"</body>\n"
+"</html>\n"
+"\n"
+"			"
 msgstr ""
 
 #. module: poweremail
@@ -234,207 +43,8 @@ msgid "\n"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
-msgid "Mailbox: Outbox"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
 #: view:poweremail.send.wizard:0
-msgid "Cancel"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,last_send_date:0
-msgid "Last Sent Date"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
-msgid "Poweremail scheduler"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,table_required_fields:0
-msgid "Required Fields"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:925
-#, python-format
-msgid "No Subject"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,sub_object:0
-msgid "Sub-model"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:154
-#, python-format
-msgid "No model reference defined"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,iserver_type:0
-msgid "IMAP"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,date_mail:0
-msgid "Rec/Sent Date"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_write:0
-msgid "Send on Update"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Server Information"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,generated:0
-msgid "No of generated Mails"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isuser:0
-#: field:poweremail.core_accounts,smtpuname:0
-msgid "User Name"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:348
-#, python-format
-msgid "IMAP Server Login Error: {}"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Suspended"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
-msgid "Email Mailbox Conversation"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.mailbox,server_ref:0
-msgid "Applicable for inward items only."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1084
-#, python-format
-msgid "IMAP Folder Statistics for Account: %s: %s"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
-msgid "Emails sent"
-msgstr ""
-
-#. module: poweremail
-#: constraint:poweremail.core_accounts:0
-msgid "Error: You are not allowed to have more than 1 account."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
-msgid "Inbox Conversations"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,mail_type:0
-msgid "Mail Contents"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "More information"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:329
-#, python-format
-msgid "%s (Email Attachment)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,state:0
-#: field:poweremail.send.wizard,state:0
-msgid "Status"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Outgoing"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Intermixed content"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.change.folder.email:0
-#: view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Finalitzar"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
-msgid "wizard.emails.generats.model"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,sub_object:0
-msgid "When a relation field is used this field will show you the type of field you have selected."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Save in Drafts"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Add here all attachments of the current document you want to include in the e-mail."
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.send.wizard,single_email:0
-#: help:poweremail.templates,single_email:0
-msgid "Check it if you want to send a single email for several records (the optional attachment will be generated as a single file for all these records). If you don't check it, an email with its optional attachment will be send for each record."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.template.attachment,search_params:0
-msgid "Search params"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,save_to_drafts_prev:0
-#: field:poweremail.templates,save_to_drafts:0
-msgid "Save to Drafts"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,copyvalue:0
-msgid "Expression"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Raw content"
+msgid " "
 msgstr ""
 
 #. module: poweremail
@@ -443,1028 +53,13 @@ msgid " BCC"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_conversation
-msgid "Conversations are groups of related emails"
+#: field:poweremail.mailbox,pem_cc:0
+msgid " CC"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.core_accounts,allowed_groups:0
-msgid "Only users from these groups will be allowed to send mails from this ID."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,name:0
-msgid "Email Account Desc"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:185
-#, python-format
-msgid "No recipient: Email cannot be sent"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:679
-#, python-format
-msgid "Copy of template "
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
-msgid "All emails"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Discard Mail"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Drafts"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:249
-#, python-format
-msgid "Not valid destiny email"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_to:0
-#: field:poweremail.templates,def_to:0
-msgid "Recepient (To)"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Body (HTML-Web Client Only)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,use_filter:0
-msgid "Active Filter"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:270
-#, python-format
-msgid "%s account not found"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1313
-#: code:addons/poweremail/poweremail_core.py:1317
-#, python-format
-msgid "Folder Error"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,table_html:0
-msgid "HTML code"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "context - current context"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,def_cc:0
-msgid "Default CC"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,def_cc:0
-msgid "The default CC for the email. Placeholders can be used here."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:935
-#, python-format
-msgid "Attachment to mail for %s relation failed Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
-msgid "Mailbox: Followup"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,file_name:0
-msgid "File name pattern can be specified with placeholders. eg. 2009_SO003.pdf"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:933
-#, python-format
-msgid "Attachment to mail for %s relation success! Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,rel_model:0
-#: field:poweremail.templates,object_name:0
-#: field:wizard.emails.generats.model,reference:0
-msgid "Model"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,table_sub_object:0
-msgid "This field shows the model you will be using for your table."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_send_wizard
-msgid "This is the wizard for sending mail"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_all
-msgid "All Accounts"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Check Outgoing Connection"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,last_mail_id:0
-msgid "Last Downloaded Mail"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,stats_interval:0
-msgid "Stats Interval"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1318
-#, python-format
-msgid "Select a folder before you save record"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:774
-#: code:addons/poweremail/poweremail_core.py:848
-#, python-format
-msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,filter:0
-msgid "The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
-"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,allowed_groups:0
-msgid "Only users from these groups will be allowed to send mails from this Template."
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,auto_email:0
-msgid "Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
-"Note: Auto email can be enabled only after saving template."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:340
-#: code:addons/poweremail/poweremail_core.py:350
-#: code:addons/poweremail/poweremail_core.py:456
-#: code:addons/poweremail/poweremail_core.py:461
-#: code:addons/poweremail/poweremail_core.py:593
-#: code:addons/poweremail/poweremail_core.py:641
-#: code:addons/poweremail/poweremail_core.py:651
-#: code:addons/poweremail/poweremail_core.py:708
-#: code:addons/poweremail/poweremail_core.py:751
-#: code:addons/poweremail/poweremail_core.py:765
-#: code:addons/poweremail/poweremail_core.py:772
-#: code:addons/poweremail/poweremail_core.py:780
-#: code:addons/poweremail/poweremail_core.py:836
-#: code:addons/poweremail/poweremail_core.py:846
-#: code:addons/poweremail/poweremail_core.py:861
-#: code:addons/poweremail/poweremail_core.py:901
-#: code:addons/poweremail/poweremail_core.py:904
-#: code:addons/poweremail/poweremail_core.py:913
-#: code:addons/poweremail/poweremail_core.py:930
-#: code:addons/poweremail/poweremail_core.py:933
-#: code:addons/poweremail/poweremail_core.py:935
-#: code:addons/poweremail/poweremail_core.py:946
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:958
-#: code:addons/poweremail/poweremail_core.py:959
-#: code:addons/poweremail/poweremail_core.py:960
-#: code:addons/poweremail/poweremail_core.py:961
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1011
-#: code:addons/poweremail/poweremail_core.py:1029
-#: code:addons/poweremail/poweremail_core.py:1048
-#: code:addons/poweremail/poweremail_core.py:1059
-#: code:addons/poweremail/poweremail_core.py:1070
-#: code:addons/poweremail/poweremail_core.py:1076
-#: code:addons/poweremail/poweremail_core.py:1082
-#: code:addons/poweremail/poweremail_core.py:1121
-#: code:addons/poweremail/poweremail_core.py:1132
-#: code:addons/poweremail/poweremail_core.py:1138
-#: code:addons/poweremail/poweremail_core.py:1144
-#: code:addons/poweremail/poweremail_core.py:1152
-#: code:addons/poweremail/poweremail_mailbox.py:60
-#: code:addons/poweremail/poweremail_mailbox.py:67
-#: code:addons/poweremail/poweremail_mailbox.py:251
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#: code:addons/poweremail/poweremail_send_wizard.py:275
-#: code:addons/poweremail/poweremail_template.py:54
-#: code:addons/poweremail/poweremail_template.py:68
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_administration_server
-#, python-format
-msgid "Power Email"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,lang:0
-msgid "The default language for the email. Placeholders can be used here. eg. ${object.partner_id.lang}"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Get Mail"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Log partner events"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,body_html:0
-#: field:poweremail.preview,body_text:0
-#: field:poweremail.send.wizard,body_html:0
-#: field:poweremail.send.wizard,body_text:0
-msgid "Body"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts_company
-msgid "Drafts"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Send Email"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "SMTP Server"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send all mails"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,iserver_type:0
-msgid "Server Type"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree_company
-msgid "Mailbox: Inbox"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:401
-#, python-format
-msgid "Incoming port is not defined"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1018
-#, python-format
-msgid "The expression in 'Reference of the report' field must contain the 'object' variable."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:275
-#, python-format
-msgid "Email sending failed for one or more objects."
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Send Type"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1029
-#, python-format
-msgid "Incoming server login attempt dropped Account: %s Check if Incoming server attributes are complete."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Approve Account"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,rel_model_ref:0
-msgid "Referred Document"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,def_to:0
-msgid "The default recepient of email. Placeholders can be used here."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-#: field:poweremail.mailbox,pem_body_text:0
-#: field:poweremail.templates,def_body_text:0
-msgid "Standard Body (Text)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.conversation,mails:0
-msgid "Related Emails"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,server_action:0
-msgid "Related Server Action"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_mailbox
-msgid "Power Email Mailbox included all type inbox,outbox,junk.."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,subject:0
-#: field:poweremail.send.wizard,subject:0
-msgid "Subject"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:403
-#, python-format
-msgid "Incoming server user name is not defined"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.preview,state:0
-#: selection:wizard.change.folder.email,state:0
-#: selection:wizard.change.state.email,wiz_state:0
-#: selection:wizard.send.email,state:0
-msgid "End"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar emails"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,send_on_write:0
-msgid "Sends an e-mail when a document is modified."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Follow Up"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Standard Body"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Email body"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,name:0
-msgid "Name of Template"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,send_count:0
-msgid "Send Count"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:334
-#, python-format
-msgid "Report"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:642
-#, python-format
-msgid "Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
-"Description: {error}"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:316
-#: code:addons/poweremail/poweremail_core.py:436
-#, python-format
-msgid "Reason: %s"
-msgstr ""
-
-#. module: poweremail
-#: constraint:ir.ui.view:0
-msgid "Invalid XML for View Architecture!"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_preview
-msgid "Power Email Template Preview"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtptls:0
-msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Body (Plain Text)"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Outbox"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:310
-#, python-format
-msgid "SMTP Test Connection Was Successful"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.conversation,from_abstract:0
-msgid "unknown"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,company:0
-msgid "Company Mail A/c"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1144
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,use_filter:0
-msgid "This option allow you to add a custom python filter before sending a mail"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_template_attachment
-msgid "poweremail.template.attachment"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:913
-#, python-format
-msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send now"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,report_template_object_reference:0
-msgid "The evaluation of this field should return the ID of the related object. For example, use: object.related_model_id.id. This ensures that the template can correctly reference the object."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
-msgid "Mailbox: Trash"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,model_int_name:0
-msgid "Model Internal Name"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body preview"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:960
-#, python-format
-msgid "IMAP Folder selected successfully Account:%s."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Static attachments"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Preview Template"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,isfolder:0
-msgid "Folder to be used for downloading IMAP mails.\n"
-"Click on adjacent button to select from a list of folders."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,from:0
-msgid "From Account"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_templates
-msgid "Power Email Templates for Models"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,enforce_from_account:0
-msgid "Email account"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:782
-#: code:addons/poweremail/poweremail_core.py:863
-#, python-format
-msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,lang:0
-#: field:poweremail.templates,lang:0
-msgid "Language"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1268
-#: code:addons/poweremail/poweremail_core.py:1271
-#, python-format
-msgid "An error occurred: %s"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:594
-#, python-format
-msgid "Cannot send mails of accounts {} when the addresses list is empty"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,report:0
-msgid "Report File Name"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,table_model_object_field:0
-msgid "Table Field"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-#: field:poweremail.mailbox,history:0
-msgid "History"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,company:0
-msgid "Select if this mail account does not belong to specific user but the organisation as a whole. eg: info@somedomain.com"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:461
-#, python-format
-msgid "Mail from Account %s failed. Probable Reason: Account not approved"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,model_data_name:0
-msgid "Code"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:710
-#, python-format
-msgid "Datetime Extraction failed. Date: %s\n"
-"Error: %s"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,record_attachment_categories:0
-msgid "Record attachment categories"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,auto_email:0
-msgid "Auto Email"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtpport:0
-msgid "SMTP Port "
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,state:0
-#: field:wizard.change.folder.email,state:0
-#: field:wizard.change.state.email,wiz_state:0
-#: field:wizard.send.email,state:0
-msgid "State"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,copyvalue:0
-msgid "Copy and paste the value in the location you want to use a system value."
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Plain Text"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,ref_ir_value:0
-msgid "Wizard Button"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "Mail fetch exception"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpport:0
-msgid "Enter port number, eg: SMTP-587 "
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1376
-#, python-format
-msgid "%s Mail Form"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1050
-#, python-format
-msgid "Starting Full mail reception for mail: %s."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-#: field:poweremail.preview,env:0
-msgid "Extra scope variables"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:98
-#: code:addons/poweremail/poweremail_send_wizard.py:99
-#, python-format
-msgid "No personal email accounts are configured for you. \n"
-"Either ask admin to enforce an account for this template or get yourself a personal power email account."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1078
-#, python-format
-msgid "IMAP Folder selected successfully Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
-msgid "Emails to sent"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "o - current object"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isfolder:0
-#: field:poweremail.mailbox,folder:0
-#: field:wizard.change.folder.email,folder:0
-msgid "Folder"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
-msgid "Trash"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Buscar correos relacionados"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Attachment settings"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1267
-#: code:addons/poweremail/poweremail_core.py:1270
-#, python-format
-msgid "IMAP Server Folder Error"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,partner_event:0
-msgid "Partner ID to log Events"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:405
-#, python-format
-msgid "Incoming server password is not defined"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:399
-#, python-format
-msgid "Incoming server is not defined"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,null_value:0
-msgid "Null Value"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,template_language:0
-msgid "Templating Language"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.conversation,name:0
-msgid "Name"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Trash"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
-msgid "Personal Accounts"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Sent"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,table_html:0
-msgid "Copy this html code to your HTML message body for displaying the info in your mail."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:296
-#, python-format
-msgid "Core connection for the given ID does not exist"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,server_action:0
-msgid "Corresponding server action is here."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "cr - database cursor"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
-#: view:wizard.send.email:0
-msgid "Enviar emails"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-#: field:poweremail.templates,filter:0
-msgid "Filter"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
-msgid "Reenviar emails amb error"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1154
-#, python-format
-msgid "Incoming server login attempt dropped Account: %s\n"
-"Check if Incoming server attributes are complete."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_template_emails
-msgid "Template emails"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
-msgid "IMAP Folder Selection Wizard"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "High"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1072
-#, python-format
-msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:224
-#, python-format
-msgid "The email must have a sending account."
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Simple Mail Wizard Step 1"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,attach_record_items:0
-msgid "Attach record items"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:62
-#, python-format
-msgid "Error receiving mail: %s"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Create send email wizard"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Send mail Wizard"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Power Email Templates"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.change.folder.email:0
-msgid "Emails canviats de carpeta!"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,record_attachment_categories:0
-msgid "Only attach record attachments with the included categories in case there's any."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:311
-#, python-format
-msgid "Error sending email with id {}: {}"
-msgstr ""
-
-#. module: poweremail
-#: field:ir.actions.server,poweremail_template:0
-#: field:poweremail.mailbox,template_id:0
-#: field:poweremail.send.wizard,ref_template:0
-#: field:poweremail.template.attachment,template_id:0
-msgid "Template"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,smtpserver:0
-msgid "Enter name of outgoing server, eg: smtp.gmail.com"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Power Email Preview"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:990
-#, python-format
-msgid "Error evaluating the expression in 'Reference of the report' field: %s"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:532
-#, python-format
-msgid "Email will be sent again"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_mail_orig:0
-msgid "Original Mail"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Body HTML"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,iserver:0
-msgid "Enter name of incoming server, eg: imap.gmail.com"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1314
-#, python-format
-msgid "This is an invalid folder"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "Check it if you want to send a single email for several records (the optional attachment will be generated as a single file for all these r ecords). If you don't check it, an email with its optional attachment will be send for each record."
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.core_accounts,email_id:0
-msgid "eg: yourname@yourdomain.com"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,attach_record_items:0
-msgid "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
-msgid "Mailbox: Sending"
-msgstr ""
-
-#. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
-msgid "Demo email subject for user ${object.login}"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email All Emails"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,dont_auto_down_attach:0
-msgid "Dont Download attachments automatically"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,folder:0
-msgid "IMAP Folder"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Automatisms settings"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isssl:0
-#: field:poweremail.core_accounts,smtpssl:0
-msgid "Use SSL"
+#: field:poweremail.mailbox,pem_subject:0
+msgid " Subject"
 msgstr ""
 
 #. module: poweremail
@@ -1473,27 +68,21 @@ msgid "${object.number}"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:456
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
-msgid "Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
-"Error: %s"
+msgid "%s (Email Attachment)"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Insert Simple Field"
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "%s Mail Form"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
-msgid "Mailbox: Sent"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,priority:0
-#: field:poweremail.send.wizard,priority:0
-msgid "Priority"
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "%s account not found"
 msgstr ""
 
 #. module: poweremail
@@ -1508,64 +97,23 @@ msgid "<!doctype html>\n"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,send_on_create:0
-msgid "Create an e-mail when a new record is created. The instance where the record is created must be restarted for the changes to take effect."
+#: field:poweremail.core_accounts,state:0
+msgid "Account Status"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
-msgid "Email Basic Templates"
+#: field:poweremail.templates,use_filter:0
+msgid "Active Filter"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:315
-#, python-format
-msgid "Out going connection test failed"
+#: field:poweremail.templates,attached_activity:0
+msgid "Activity"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
-msgid "Sent"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:416
-#, python-format
-msgid "The specified record for connection does not exist"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#, python-format
-msgid "Please specify an template to use for auto email in poweremail!"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Mako Templates"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,def_priority:0
-msgid "Default priority"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_send_email
-msgid "wizard.send.email"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtptls:0
-msgid "Use TLS"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
-msgid "Mailbox: All emails"
+#: view:poweremail.send.wizard:0
+msgid "Add here all attachments of the current document you want to include in the e-mail."
 msgstr ""
 
 #. module: poweremail
@@ -1575,163 +123,191 @@ msgid "Advanced"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
-#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
-#: selection:poweremail.mailbox,state:0
-msgid "Sending"
+#: view:poweremail.send.wizard:0
+msgid "After clicking send all mails, mails will be sent to outbox and cleared in next Send/Recieve"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:959
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_all
+msgid "All Accounts"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_all_emails_company
+msgid "All emails"
+msgstr ""
+
+#. module: poweremail
+#: view:ir.actions.server:0
+msgid "All values for the mail can be configured in the template editor itself."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,allowed_groups:0
+#: field:poweremail.templates,allowed_groups:0
+#: view:poweremail.templates:0
+msgid "Allowed User Groups"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "IMAP Server Folder Selection Error Account: %s Error: %s.\n"
-"Check account settings if you have selected a folder."
+msgid "An error occurred while rendering template id {}:  {}"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,state:0
-msgid "Account Status"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.preview,enforce_from_account:0
-msgid "Email will be sent from this account."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1003
-#: code:addons/poweremail/poweremail_core.py:1123
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "POP3 Server Error Account: %s Error: %s."
+msgid "An error occurred: %s"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.mailbox,server_ref:0
+msgid "Applicable for inward items only."
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "Select Folder"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:245
-#, python-format
-msgid "Email sent successfully"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,smtpserver:0
-msgid "Server"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,send_immediately:0
-msgid "Emails created from this template will be sent immediately without going through outbox folder."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:953
-#: code:addons/poweremail/poweremail_core.py:1061
-#, python-format
-msgid "IMAP Server Connected & logged in successfully Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1010
-#: code:addons/poweremail/poweremail_core.py:1140
-#, python-format
-msgid "POP3 Server Connected & logged in successfully Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Other settings"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_subject:0
-msgid " Subject"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Mail Details"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:295
-#, python-format
-msgid "SMTP SERVER or PORT not specified"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "The file name must follow the format: TEXT.LANGUAGE.EXTENSION (for example: extraordinary_meeting.en_EN.pdf) to identify the document by language."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Power Email Configuration"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "Yes"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,send_immediately:0
-msgid "Send Immediately"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:396
-#, python-format
-msgid "From Poweremail Mailbox {} Original email as {}"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:652
-#, python-format
-msgid "Sending mail from Account {} failed.\n"
-"Description: {}"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:930
-#, python-format
-msgid "Downloaded & saved %s attachments Account: %s."
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Low"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
-msgid "My Account"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Request Re-activation"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1009
-#: code:addons/poweremail/poweremail_core.py:1134
-#, python-format
-msgid "POP3 Server Login Error Account: %s Error: %s."
+msgid "Approve Account"
 msgstr ""
 
 #. module: poweremail
 #: selection:poweremail.core_accounts,state:0
-msgid "Initiated"
+msgid "Approved"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,signature:0
+msgid "Attach my signature to mail"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,attach_record_items:0
+msgid "Attach record items"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Attachment settings"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Attachment to mail for %s relation failed Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Attachment to mail for %s relation success! Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_attachments_ids:0
+#: field:poweremail.send.wizard,attachment_ids:0
+#: field:poweremail.templates,ir_attachment_ids:0
+#: field:poweremail.templates,tmpl_attachment_ids:0
+#: view:poweremail.mailbox:0
+#: view:poweremail.send.wizard:0
+#: view:poweremail.template.attachment:0
+msgid "Attachments"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,auto_email:0
+msgid "Auto Email"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Automatisms settings"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Available global variables:"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,bcc:0
+#: field:poweremail.send.wizard,bcc:0
+msgid "BCC"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,body_html:0
+#: field:poweremail.preview,body_text:0
+#: field:poweremail.send.wizard,body_html:0
+#: field:poweremail.send.wizard,body_text:0
+msgid "Body"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.send.wizard:0
-msgid "Tip: Multiple emails are sent in the same language (the first one is proposed). We suggest you send emails in groups according to langu age."
+#: view:poweremail.templates:0
+msgid "Body (HTML)"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Body (Plain Text)"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Body (Text)"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_html:0
+#: field:poweremail.templates,def_body_html:0
+msgid "Body (Text-Web Client Only)"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body HTML"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Body preview"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Both HTML & Text"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
+#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
+msgid "Buscar Correus Relacionats"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar correos relacionados"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Buscar emails"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,cc:0
+#: field:poweremail.send.wizard,cc:0
+msgid "CC"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+#: view:poweremail.send.wizard:0
+msgid "Cancel"
 msgstr ""
 
 #. module: poweremail
@@ -1742,35 +318,9 @@ msgid "Cancel·lar"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
-msgid "Outbox"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_message_id:0
-msgid "Message-Id"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,model_ref:0
-msgid "Template reference"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,cc:0
-#: field:poweremail.send.wizard,cc:0
-msgid "CC"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Send Mail"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,report_template_object_reference:0
-msgid "Reference of the report"
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Cannot send mails of accounts {} when the addresses list is empty"
 msgstr ""
 
 #. module: poweremail
@@ -1780,42 +330,339 @@ msgid "Canviar emails de carpeta"
 msgstr ""
 
 #. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
+#: view:wizard.change.state.email:0
+msgid "Canviar estat dels emails"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Incoming Connection"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Check Outgoing Connection"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Check it if you want to send a single email for several records (the optional attachment will be generated as a single file for all these r ecords). If you don't check it, an email with its optional attachment will be send for each record."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.send.wizard,single_email:0
+#: help:poweremail.templates,single_email:0
+msgid "Check it if you want to send a single email for several records (the optional attachment will be generated as a single file for all these records). If you don't check it, an email with its optional attachment will be send for each record."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Close"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,model_data_name:0
+msgid "Code"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
+msgid "Company"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
+msgid "Company Accounts"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,company:0
+msgid "Company Mail A/c"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,full_success:0
+msgid "Complete Success"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
+msgid "Configuration"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Content"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,conversation_id:0
+msgid "Conversation"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_conversation
+msgid "Conversations are groups of related emails"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,copyvalue:0
+msgid "Copy and paste the value in the location you want to use a system value."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Copy of template "
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,table_html:0
+msgid "Copy this html code to your HTML message body for displaying the info in your mail."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Core connection for the given ID does not exist"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,server_action:0
+msgid "Corresponding server action is here."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Could not create mail \"{subject}\" from Account \"{account.name}\".\n"
+"Description: {error}"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,send_on_create:0
+msgid "Create an e-mail when a new record is created. The instance where the record is created must be restarted for the changes to take effect."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Create send email wizard"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,create_date:0
+msgid "Created date"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,write_date:0
+msgid "Date modified"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Datetime Extraction failed. Date: %s\n"
+"Error: %s"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,def_bcc:0
+msgid "Default BCC"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,def_cc:0
+msgid "Default CC"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,def_subject:0
+msgid "Default Subject"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,def_priority:0
+msgid "Default priority"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,def_priority:0
+msgid "Default priority for auto generated emails"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Deletion of Record failed"
+msgstr ""
+
+#. module: poweremail
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail
+msgid "Demo email subject for user ${object.login}"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Discard Mail"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Django templates not installed"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,dont_auto_down_attach:0
+msgid "Dont Download attachments automatically"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Download Full Mail"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Downloaded & saved %s attachments Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_drafts_company
+msgid "Drafts"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Dynamic attachments (reports)"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Editor (HTML)"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,name:0
+msgid "Email Account"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,name:0
+msgid "Email Account Desc"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_basic_template_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_basic_templates_all
+msgid "Email Basic Templates"
+msgstr ""
+
+#. module: poweremail
 #: view:ir.actions.server:0
 msgid "Email Configuration"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:242
+#: field:poweremail.core_accounts,email_id:0
+msgid "Email ID"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_conversation_tree
+msgid "Email Mailbox Conversation"
+msgstr ""
+
+#. module: poweremail
+#: field:ir.actions.report.xml,poweremail_template_ids:0
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
+msgid "Email Templates"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,enforce_from_account:0
+msgid "Email account"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Email body"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
 #, python-format
-msgid "An error occurred while rendering template id {}:  {}"
+msgid "Email sending failed for one or more objects."
 msgstr ""
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
-msgid "Mailbox: Error"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.mailbox:0
-#: field:poweremail.mailbox,pem_attachments_ids:0
-#: view:poweremail.send.wizard:0
-#: field:poweremail.send.wizard,attachment_ids:0
-#: view:poweremail.template.attachment:0
-#: field:poweremail.templates,ir_attachment_ids:0
-#: field:poweremail.templates,tmpl_attachment_ids:0
-msgid "Attachments"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,model_object_field:0
-msgid "Field"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:753
+#: code:addons/poweremail/poweremail_mailbox.py:0
 #, python-format
-msgid "Saving Header of unknown payload (%s) Account: %s."
+msgid "Email sent successfully"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Email will be sent again"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.preview,enforce_from_account:0
+msgid "Email will be sent from this account."
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.change.state.email:0
+msgid "Emails canviats d'estat!"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0
+msgid "Emails canviats de carpeta!"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,send_immediately:0
+msgid "Emails created from this template will be sent immediately without going through outbox folder."
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.send.email:0
+msgid "Emails enviats!"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Emails for multiple items saved in outbox."
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
+msgid "Emails in error folder"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent
+msgid "Emails sent"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
+msgid "Emails sent today"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_to_sent
+msgid "Emails to sent"
 msgstr ""
 
 #. module: poweremail
@@ -1824,20 +671,405 @@ msgid "Emails will be sent only from this account."
 msgstr ""
 
 #. module: poweremail
-#: constraint:ir.model:0
-msgid "The Object name must start with x_ and not contain any special character !"
+#: selection:poweremail.preview,state:0
+#: selection:wizard.change.folder.email,state:0
+#: selection:wizard.change.state.email,wiz_state:0
+#: selection:wizard.send.email,state:0
+msgid "End"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "After clicking send all mails, mails will be sent to outbox and cleared in next Send/Recieve"
+#: view:wizard.change.folder.email:0
+#: view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Endavant"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,allowed_groups:0
+#: field:poweremail.templates,enforce_from_account:0
+msgid "Enforce From Account"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,iserver:0
+msgid "Enter name of incoming server, eg: imap.gmail.com"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpserver:0
+msgid "Enter name of outgoing server, eg: smtp.gmail.com"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpport:0
+msgid "Enter port number, eg: SMTP-587 "
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_wizard_send_email_form
+#: view:wizard.send.email:0
+msgid "Enviar emails"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_serveraction.py:0
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
+#: selection:poweremail.preview,state:0
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error receiving mail: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending email with id {}: {}"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Error sending mail: %s"
+msgstr ""
+
+#. module: poweremail
+#: constraint:poweremail.core_accounts:0
+msgid "Error: You are not allowed to have more than 1 account."
+msgstr ""
+
+#. module: poweremail
+#: field:wizard.change.state.email,estat:0
+msgid "Estat"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,copyvalue:0
+msgid "Expression"
+msgstr ""
+
+#. module: poweremail
 #: view:poweremail.templates:0
-#: field:poweremail.templates,allowed_groups:0
-msgid "Allowed User Groups"
+msgid "Expression builder"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,env:0
+#: view:poweremail.preview:0
+msgid "Extra scope variables"
+msgstr ""
+
+#. module: poweremail
+#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
+msgid "Factura ${object.number}"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,model_object_field:0
+msgid "Field"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,file_name:0
+msgid "File Name Pattern"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.template.attachment,file_name:0
+msgid "File name"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,file_name:0
+msgid "File name pattern can be specified with placeholders. eg. 2009_SO003.pdf"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,filter:0
+#: view:poweremail.templates:0
+msgid "Filter"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.change.folder.email:0
+#: view:wizard.change.state.email:0
+#: view:wizard.send.email:0
+msgid "Finalitzar"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,rec_headers_den_mail:0
+msgid "First Receive headers, then download mail"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isfolder:0
+#: field:poweremail.mailbox,folder:0
+#: field:wizard.change.folder.email,folder:0
+msgid "Folder"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Folder Error"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isfolder:0
+msgid "Folder to be used for downloading IMAP mails.\n"
+"Click on adjacent button to select from a list of folders."
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
+msgid "Follow-up"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,isport:0
+msgid "For example IMAP: 993,POP3:995"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_from:0
+msgid "From"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,from:0
+msgid "From Account"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "From Poweremail Mailbox {} Original email as {}"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "Generated Email"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Get Mail"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "HTML Body"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,table_html:0
+msgid "HTML code"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "HTML otherwise Text"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Has Attachments"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Header for Mail %s Saved successfully as ID: %s for Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "High"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,history:0
+msgid "History"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "IMAP"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_selfolder,folder:0
+msgid "IMAP Folder"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.act_selfolder_form
+msgid "IMAP Folder Selection Wizard"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder Statistics for Account: %s: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Folder selected successfully Account:%s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error Account: %s, Mail: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Mail -> Mailbox create error. Account: %s, Mail: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Connected & logged in successfully Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Error: {}"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Error"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error Account: %s Error: %s.\n"
+"Check account settings if you have selected a folder."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Folder Selection Error. Account: %s Error: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "IMAP Server Login Error: {}"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,inline:0
+msgid "If the option is checked, the CSS will be inlined inside the HTML"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "In coming connection test failed"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
+msgid "Inbox"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_conversation
+msgid "Inbox Conversations"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Incoming"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,iserver:0
+msgid "Incoming Server"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming Test Connection Was Successful"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming port is not defined"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server is not defined"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server login attempt dropped Account: %s\n"
+"Check if Incoming server attributes are complete."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server login attempt dropped Account: %s Check if Incoming server attributes are complete."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server password is not defined"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Incoming server user name is not defined"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Information"
 msgstr ""
 
 #. module: poweremail
@@ -1849,32 +1081,432 @@ msgid "Init"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "User Information"
+#: selection:poweremail.core_accounts,state:0
+msgid "Initiated"
 msgstr ""
 
 #. module: poweremail
-#: view:wizard.send.email:0
-msgid "Emails enviats!"
+#: field:poweremail.templates,inline:0
+msgid "Inline HTML"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:214
+#: view:poweremail.templates:0
+msgid "Insert Simple Field"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Insert Table"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Intermixed content"
+msgstr ""
+
+#. module: poweremail
+#: constraint:ir.ui.view:0
+msgid "Invalid XML for View Architecture! Check server logs for details (view name, model, line number and RNG error)."
+msgstr ""
+
+#. module: poweremail
+#: constraint:ir.cron:0
+msgid "Invalid arguments"
+msgstr ""
+
+#. module: poweremail
+#: constraint:ir.actions.act_window:0
+msgid "Invalid model name in the action definition."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,lang:0
+#: field:poweremail.templates,lang:0
+msgid "Language"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,last_mail_id:0
+msgid "Last Downloaded Mail"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,last_send_date:0
+msgid "Last Sent Date"
+msgstr ""
+
+#. module: poweremail
+#: view:wizard.emails.generats.model:0
+msgid "Llistar correus relacionats"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Log partner events"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Logs"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Low"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "The body of the email must not be empty."
+msgid "Mail %s Saved successfully as ID: %s for Account: %s."
 msgstr ""
 
 #. module: poweremail
-#: view:wizard.change.folder.email:0
-#: view:wizard.change.state.email:0
-#: view:wizard.send.email:0
-msgid "Endavant"
+#: field:poweremail.mailbox,mail_type:0
+msgid "Mail Contents"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.preview,save_to_drafts_prev:0
-#: help:poweremail.templates,save_to_drafts:0
-msgid "When automatically sending emails generated from this template, save them into the Drafts folder rather than sending them immediately."
+#: view:poweremail.templates:0
+msgid "Mail Details"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,send_pref:0
+msgid "Mail Format"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Mail fetch exception"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail from Account %s failed on login. Probable Reason: Could not login to server\n"
+"Error: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Mail from Account %s failed. Probable Reason: Account not approved"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_mailbox_all_main2
+msgid "MailBox"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_all_emails_tree_company
+msgid "Mailbox: All emails"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_drafts_tree_company
+msgid "Mailbox: Drafts"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_company
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_error_tree_personal
+msgid "Mailbox: Error"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_follow_tree_company
+msgid "Mailbox: Followup"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_inbox_tree_company
+msgid "Mailbox: Inbox"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_outbox_tree_company
+msgid "Mailbox: Outbox"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sending_tree_company
+msgid "Mailbox: Sending"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_sent_tree_company
+msgid "Mailbox: Sent"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_trash_tree_company
+msgid "Mailbox: Trash"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.templates,template_language:0
+msgid "Mako Templates"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Mako templates not installed"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_message_id:0
+msgid "Message-Id"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,rel_model:0
+#: field:poweremail.templates,object_name:0
+#: field:wizard.emails.generats.model,reference:0
+msgid "Model"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,model_data_name:0
+msgid "Model Data Name."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,model_int_name:0
+msgid "Model Internal Name"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "More information"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.send.wizard,state:0
+msgid "Multiple Mail Wizard Step 1"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_my
+msgid "My Account"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_my
+msgid "My Accounts"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.conversation,name:0
+msgid "Name"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,name:0
+msgid "Name of Template"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,company:0
+msgid "No"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "No Description"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "No Subject"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No information on which mail should be fetched fully"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "No model reference defined"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,generated:0
+msgid "No of generated Mails"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,requested:0
+msgid "No of requested Mails"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "No personal email accounts are configured for you. \n"
+"Either ask admin to enforce an account for this template or get yourself a personal power email account."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "No recipient: Email cannot be sent"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,priority:0
+#: selection:poweremail.send.wizard,priority:0
+#: selection:poweremail.templates,def_priority:0
+msgid "Normal"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Not Applicable"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Not valid destiny email"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Note: HTML body can't be edited with GTK desktop client."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,null_value:0
+msgid "Null Value"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,stats_interval:0
+msgid "Number of days used to calculate the send count backwards from today. If empty or zero, all sent emails are taken into account."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "OK"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_selfolder:0
+msgid "Ok"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,record_attachment_categories:0
+msgid "Only attach record attachments with the included categories in case there's any."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,allowed_groups:0
+msgid "Only users from these groups will be allowed to send mails from this ID."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,allowed_groups:0
+msgid "Only users from these groups will be allowed to send mails from this Template."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "OpenObject Code Filter:"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_mail_orig:0
+msgid "Original Mail"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Other settings"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_company_others
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal_others
+msgid "Others"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Out going connection test failed"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_outbox_company
+msgid "Outbox"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Outgoing"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,iserver_type:0
+msgid "POP3"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Connected & logged in successfully Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Error Account: %s Error: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Server Login Error Account: %s Error: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "POP3 Statistics: %s mails of %s size for Account: %s:"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,partner_event:0
+msgid "Partner ID to log Events"
 msgstr ""
 
 #. module: poweremail
@@ -1886,87 +1518,29 @@ msgid "Partner ID who an email event is logged.\n"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:183
-#, python-format
-msgid "Generated Email"
+#: field:poweremail.core_accounts,ispass:0
+#: field:poweremail.core_accounts,smtppass:0
+msgid "Password"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Expression builder"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
+msgid "Personal"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_poweremail_core_accounts
-msgid "poweremail.core_accounts"
+#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_per
+msgid "Personal Account"
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Text otherwise HTML"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal
+msgid "Personal Accounts"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.send.wizard:0
-#: view:poweremail.templates:0
-msgid "Body (HTML)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,attached_activity:0
-msgid "Activity"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Remove send email wizard"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.change.state.email:0
-msgid "Emails canviats d'estat!"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:901
-#, python-format
-msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,enforce_from_account:0
-msgid "Enforce From Account"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Dynamic attachments (reports)"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,send_pref:0
-msgid "Mail Format"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "uid - current user ID"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,isport:0
-msgid "Port"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_send_wizard.py:269
-#, python-format
-msgid "Emails for multiple items saved in outbox."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,send_on_create:0
-msgid "Send on Create"
+#: selection:poweremail.mailbox,mail_type:0
+msgid "Plain Text"
 msgstr ""
 
 #. module: poweremail
@@ -1975,166 +1549,44 @@ msgid "Plain Text & HTML with no attachments"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
+#: code:addons/poweremail/poweremail_serveraction.py:0
 #, python-format
-msgid "Deletion of Record failed"
+msgid "Please specify an template to use for auto email in poweremail!"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:342
+#: field:poweremail.core_accounts,isport:0
+msgid "Port"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#: code:addons/poweremail/poweremail_template.py:0
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_administration_server
 #, python-format
-msgid "IMAP Server Error: {}"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_company
-msgid "Company"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:767
-#: code:addons/poweremail/poweremail_core.py:838
-#, python-format
-msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,create_date:0
-msgid "Created date"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,state:0
-msgid "Approved"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:219
-#, python-format
-msgid "The email must have a destiny account."
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:373
-#, python-format
-msgid "Programming Error in _get_pop3_server method. The record received is invalid."
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_selfolder:0
-msgid "Ok"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.template.attachment,file_name:0
-msgid "File name"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_recd:0
-msgid "Received at"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_selfolder,name:0
-msgid "Email Account"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:1011
-#, python-format
-msgid "POP3 Statistics: %s mails of %s size for Account: %s"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,bcc:0
-#: field:poweremail.send.wizard,bcc:0
-msgid "BCC"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.core_accounts,email_id:0
-msgid "Email ID"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,full_success:0
-msgid "Complete Success"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.send.wizard:0
-msgid "OK"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_change_folder_email
-msgid "wizard.change.folder.email"
+msgid "Power Email"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.mailbox:0
-msgid "Download Full Mail"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "Both HTML & Text"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:671
-#, python-format
-msgid "Warning"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_follow_company
-msgid "Follow-up"
+msgid "Power Email All Emails"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "security"
+msgid "Power Email Configuration"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.templates,ref_ir_act_window:0
-msgid "Window Action"
+#: view:poweremail.conversation:0
+msgid "Power Email Conversation"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.templates:0
-msgid "Wizard send email"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:106
-#, python-format
-msgid "No information on which mail should be fetched fully"
-msgstr ""
-
-#. module: poweremail
-#: model:poweremail.templates,def_body_text:poweremail.default_template_poweremail_2
-msgid "\n"
-"\n"
-"<!doctype html>\n"
-"<html>\n"
-"<head></head>\n"
-"<body>\n"
-"Benvolgut/da ${object.login},\n"
-"\n"
-"Això és un email generic de prova per les poweremail_camapign.\n"
-"\n"
-"\n"
-"Atentament,\n"
-"\n"
-"un mort de gana.\n"
-"</body>\n"
-"</html>\n"
-"\n"
-"			"
+#: view:poweremail.mailbox:0
+msgid "Power Email Drafts"
 msgstr ""
 
 #. module: poweremail
@@ -2143,86 +1595,178 @@ msgid "Power Email Error"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_body_html:0
-#: field:poweremail.templates,def_body_html:0
-msgid "Body (Text-Web Client Only)"
+#: view:poweremail.mailbox:0
+msgid "Power Email Follow Up"
 msgstr ""
 
 #. module: poweremail
-#: field:wizard.change.state.email,estat:0
-msgid "Estat"
+#: view:poweremail.mailbox:0
+msgid "Power Email Inbox"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,table_required_fields:0
-msgid "Select the fields you require in the table."
+#: model:ir.model,name:poweremail.model_poweremail_mailbox
+msgid "Power Email Mailbox included all type inbox,outbox,junk.."
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.templates,template_language:0
-msgid "Django Template"
+#: view:poweremail.mailbox:0
+msgid "Power Email Outbox"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,def_priority:0
-msgid "Default priority for auto generated emails"
+#: view:poweremail.preview:0
+msgid "Power Email Preview"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.templates,use_sign:0
-msgid "Use Signature"
+#: view:poweremail.mailbox:0
+msgid "Power Email Sent"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_account_id:0
-msgid "User account"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.send.wizard,signature:0
-msgid "Attach my signature to mail"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:438
-#, python-format
-msgid "Incoming Test Connection Was Successful"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_sent_today
-msgid "Emails sent today"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_configuration_server
-msgid "Configuration"
-msgstr ""
-
-#. module: poweremail
-#: constraint:ir.cron:0
-msgid "Invalid arguments"
-msgstr ""
-
-#. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "HTML Body"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:435
-#, python-format
-msgid "In coming connection test failed"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,sub_model_object_field:0
-msgid "When you choose relationship fields this field will specify the sub value you can use."
+#: model:ir.model,name:poweremail.model_poweremail_preview
+msgid "Power Email Template Preview"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Body (Text)"
+msgid "Power Email Templates"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_templates
+msgid "Power Email Templates for Models"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Power Email Trash"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.cron,name:poweremail.ir_cron_mail_scheduler_action
+msgid "Poweremail scheduler"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.module.module,shortdesc:poweremail.module_meta_information
+msgid "Powerful Email capabilities for Open ERP"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Preview"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Preview Email"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Preview Template"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,priority:0
+#: field:poweremail.send.wizard,priority:0
+msgid "Priority"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Programming Error in _get_pop3_server method. The record received is invalid."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Raw content"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.mailbox,state:0
+msgid "Read"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Reason: %s"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,date_mail:0
+msgid "Rec/Sent Date"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_recd:0
+msgid "Received at"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_to:0
+#: field:poweremail.templates,def_to:0
+msgid "Recepient (To)"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,record_attachment_categories:0
+msgid "Record attachment categories"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.cron,name:poweremail.ir_cron_reenviar_emails_error
+msgid "Reenviar emails amb error"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,rel_model_ref:0
+msgid "Referred Document"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.conversation,mails:0
+msgid "Related Emails"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,server_action:0
+msgid "Related Server Action"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,user:0
+msgid "Related User"
+msgstr ""
+
+#. module: poweremail
+#: view:ir.actions.report.xml:0
+msgid "Related email templates"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Remove send email wizard"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_send_wizard.py:0
+#, python-format
+msgid "Report"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,report:0
+msgid "Report File Name"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,report:0
+msgid "Report Name"
 msgstr ""
 
 #. module: poweremail
@@ -2232,122 +1776,92 @@ msgid "Report to send"
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.send.wizard,state:0
-msgid "Multiple Mail Wizard Step 1"
+#: view:poweremail.core_accounts:0
+msgid "Request Re-activation"
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,send_pref:0
-msgid "HTML otherwise Text"
+#: field:poweremail.templates,table_required_fields:0
+msgid "Required Fields"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,user:0
-msgid "Related User"
+#: field:poweremail.core_accounts,smtpport:0
+msgid "SMTP Port "
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.core_accounts,company:0
-msgid "No"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_mailbox_error
-msgid "Emails in error folder"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.preview:0
-msgid "Preview Email"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_from:0
-msgid "From"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:996
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "The expression in 'Reference of the report' field returned an empty value or a value that is not an integer ID."
+msgid "SMTP SERVER or PORT not specified"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.core_accounts:0
-msgid "Suspend Account"
+msgid "SMTP Server"
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.mailbox,priority:0
-#: selection:poweremail.send.wizard,priority:0
-#: selection:poweremail.templates,def_priority:0
-msgid "Normal"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.templates:0
-msgid "Available global variables:"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_form
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_template_tree_all
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates_all
-msgid "Email Templates"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,sub_model_object_field:0
-msgid "Sub Field"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,pem_user:0
-msgid "User"
-msgstr ""
-
-#. module: poweremail
-#: model:poweremail.templates,def_subject:poweremail.default_template_poweremail_2
-msgid "Factura ${object.number}"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.mailbox,write_date:0
-msgid "Date modified"
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.templates,file_name:0
-msgid "File Name Pattern"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1397
-#: code:addons/poweremail/poweremail_template.py:1411
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Send Mail (%s)"
+msgid "SMTP Test Connection Was Successful"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:213
-#: code:addons/poweremail/poweremail_mailbox.py:218
-#: code:addons/poweremail/poweremail_mailbox.py:223
-#: code:addons/poweremail/poweremail_serveraction.py:89
-#: code:addons/poweremail/poweremail_template.py:989
-#: code:addons/poweremail/poweremail_template.py:995
-#: code:addons/poweremail/poweremail_template.py:1017
-#: code:addons/poweremail/poweremail_template.py:1026
-#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:153
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_company
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_error_personal
-#: selection:poweremail.preview,state:0
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Error"
+msgid "Save Header -> Mailbox create error. Account: %s, Mail: %s, Error: %s"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,iserver:0
-msgid "Incoming Server"
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Save Mail -> Mailbox write error Account: %s, Mail: %s"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Save in Drafts"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,save_to_drafts_prev:0
+#: field:poweremail.templates,save_to_drafts:0
+msgid "Save to Drafts"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Saving Header of unknown payload (%s) Account: %s."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.template.attachment,search_params:0
+msgid "Search params"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Select Folder"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Select a folder before you save record"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,company:0
+msgid "Select if this mail account does not belong to specific user but the organisation as a whole. eg: info@somedomain.com"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,model_object_field:0
+msgid "Select the field from the model you want to use.\n"
+"If it is a relationship field you will be able to choose the nested values in the box below.\n"
+"(Note: If there are no values make sure you have selected the correct model)."
 msgstr ""
 
 #. module: poweremail
@@ -2357,30 +1871,361 @@ msgid "Select the field from the model you want to use.\n"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:1027
+#: help:poweremail.templates,table_required_fields:0
+msgid "Select the fields you require in the table."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,auto_email:0
+msgid "Selecting Auto Email will create a server action for you which automatically sends mail after a new record is created.\n"
+"Note: Auto email can be enabled only after saving template."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,send_count:0
+msgid "Send Count"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.preview:0
+msgid "Send Email"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,send_immediately:0
+msgid "Send Immediately"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.mailbox:0
+msgid "Send Mail"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
 #, python-format
-msgid "No records found evaluating the expression in 'Reference of the report' field."
+msgid "Send Mail (%s)"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_template.py:70
+#: selection:poweremail.send.wizard,state:0
+msgid "Send Type"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send all mails"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send mail Wizard"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.send.wizard:0
+msgid "Send now"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_create:0
+msgid "Send on Create"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,send_on_write:0
+msgid "Send on Update"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Send/Receive"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree
+#: model:ir.ui.menu,name:poweremail.menu_action_poweremail_sending_tree_company
+#: selection:poweremail.mailbox,state:0
+msgid "Sending"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
 #, python-format
-msgid "Django templates not installed"
+msgid "Sending mail from Account {} failed.\n"
+"Description: {}"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.conversation:0
-msgid "Power Email Conversation"
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "Sending of Mail %s failed. Probable Reason: Could not login to server\n"
+"Error: %s"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.model,name:poweremail.model_wizard_change_state_email
-msgid "wizard.change.state.email"
+#: help:poweremail.templates,send_on_write:0
+msgid "Sends an e-mail when a document is modified."
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.mailbox,pem_cc:0
-msgid " CC"
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_sent_company
+msgid "Sent"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,smtpserver:0
+msgid "Server"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Server Information"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,server_ref:0
+msgid "Server Reference of mail"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,iserver_type:0
+msgid "Server Type"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_core_selfolder
+msgid "Shows a list of IMAP folders"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,attach_record_items:0
+msgid "Si es marca aquesta opcio, s'enviaran com a fitxers adjunts del email tots els adjunts del registre utilitzat per renderitzar el email."
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.send.wizard,state:0
+msgid "Simple Mail Wizard Step 1"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.send.wizard,single_email:0
+#: field:poweremail.templates,single_email:0
+msgid "Single email"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_body_text:0
+#: field:poweremail.templates,def_body_text:0
+msgid "Standard Body (Text)"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtpssl:0
+msgid "Start a SMTP connection through SSL (Usually port 465)"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.core_accounts,smtptls:0
+msgid "Start a TLS connection after the SMTP connection (Usually port 587)"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Full mail reception for mail: %s."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "Starting Header reception for account: %s."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,state:0
+#: field:wizard.change.folder.email,state:0
+#: field:wizard.change.state.email,wiz_state:0
+#: field:wizard.send.email,state:0
+msgid "State"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Static attachments"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "Stats"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,stats_interval:0
+msgid "Stats Interval"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,state:0
+#: field:poweremail.send.wizard,state:0
+msgid "Status"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,sub_model_object_field:0
+msgid "Sub Field"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,sub_object:0
+msgid "Sub-model"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,subject:0
+#: field:poweremail.send.wizard,subject:0
+msgid "Subject"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "Suspend Account"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,state:0
+msgid "Suspended"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,table_model_object_field:0
+msgid "Table Field"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,table_sub_object:0
+msgid "Table-model"
+msgstr ""
+
+#. module: poweremail
+#: field:ir.actions.server,poweremail_template:0
+#: field:poweremail.mailbox,template_id:0
+#: field:poweremail.send.wizard,ref_template:0
+#: field:poweremail.template.attachment,template_id:0
+msgid "Template"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
+msgid "Template Preview"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.actions.act_window,name:poweremail.action_template_emails
+msgid "Template emails"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.preview,model_ref:0
+msgid "Template reference"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
+msgid "Templates"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,template_language:0
+msgid "Templating Language"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.core_accounts,send_pref:0
+msgid "Text otherwise HTML"
+msgstr ""
+
+#. module: poweremail
+#: constraint:ir.model:0
+msgid "The Object name must start with x_ and not contain any special character !"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "The body of the email must not be empty."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,def_bcc:0
+msgid "The default BCC for the email. Placeholders can be used here."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,def_cc:0
+msgid "The default CC for the email. Placeholders can be used here."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,lang:0
+msgid "The default language for the email. Placeholders can be used here. eg. ${object.partner_id.lang}"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,def_to:0
+msgid "The default recepient of email. Placeholders can be used here."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,def_subject:0
+msgid "The default subject of email. Placeholders can be used here."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/wizard/wizard_poweremail_preview.py:0
+#, python-format
+msgid "The email address is not valid."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "The email must have a destiny account."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_mailbox.py:0
+#, python-format
+msgid "The email must have a sending account."
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "The file name must follow the format: TEXT.LANGUAGE.EXTENSION (for example: extraordinary_meeting.en_EN.pdf) to identify the document by language."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,filter:0
+msgid "The python code entered here will be excecuted if theresult is True the mail will be send if it false the mail won't be send.\n"
+"Example : o.type == 'out_invoice' and o.number and o.number[:3]<>'os_' "
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,use_sign:0
+msgid "The signature from the User details will be appened to the mail."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "The specified record for connection does not exist"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "The template name must be unique!"
 msgstr ""
 
 #. module: poweremail
@@ -2390,34 +2235,34 @@ msgid "The text version of the mail."
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,use_sign:0
-msgid "The signature from the User details will be appened to the mail."
+#: help:poweremail.templates,null_value:0
+msgid "This Value is used if the field is empty."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,table_sub_object:0
+msgid "This field shows the model you will be using for your table."
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_core.py:0
+#, python-format
+msgid "This is an invalid folder"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_poweremail_send_wizard
+msgid "This is the wizard for sending mail"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,use_filter:0
+msgid "This option allow you to add a custom python filter before sending a mail"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.send.wizard:0
-msgid "Close"
-msgstr ""
-
-#. module: poweremail
-#: code:addons/poweremail/poweremail_mailbox.py:69
-#, python-format
-msgid "Error sending mail: %s"
-msgstr ""
-
-#. module: poweremail
-#: view:wizard.emails.generats.model:0
-msgid "Llistar correus relacionats"
-msgstr ""
-
-#. module: poweremail
-#: view:poweremail.core_accounts:0
-msgid "Check Incoming Connection"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_personal
-msgid "Personal"
+msgid "Tip: Multiple emails are sent in the same language (the first one is proposed). We suggest you send emails in groups according to langu age."
 msgstr ""
 
 #. module: poweremail
@@ -2427,114 +2272,172 @@ msgid "To"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.core_accounts,isport:0
-msgid "For example IMAP: 993,POP3:995"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_emails_generats_model
-#: model:ir.ui.menu,name:poweremail.menu_wizard_emails_generats
-msgid "Buscar Correus Relacionats"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,def_bcc:0
-msgid "The default BCC for the email. Placeholders can be used here."
-msgstr ""
-
-#. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_templates
-msgid "Templates"
-msgstr ""
-
-#. module: poweremail
-#: help:poweremail.templates,def_subject:0
-msgid "The default subject of email. Placeholders can be used here."
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash
+#: model:ir.ui.menu,name:poweremail.menu_poweremail_trash_company
+msgid "Trash"
 msgstr ""
 
 #. module: poweremail
 #: selection:poweremail.mailbox,state:0
-msgid "Read"
+msgid "Un-Read"
 msgstr ""
 
 #. module: poweremail
-#: help:poweremail.templates,inline:0
-msgid "If the option is checked, the CSS will be inlined inside the HTML"
+#: field:poweremail.core_accounts,isssl:0
+#: field:poweremail.core_accounts,smtpssl:0
+msgid "Use SSL"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,rec_headers_den_mail:0
-msgid "First Receive headers, then download mail"
+#: field:poweremail.templates,use_sign:0
+msgid "Use Signature"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,smtptls:0
+msgid "Use TLS"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_user:0
+msgid "User"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.core_accounts:0
+msgid "User Information"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.core_accounts,isuser:0
+#: field:poweremail.core_accounts,smtpuname:0
+msgid "User Name"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.mailbox,pem_account_id:0
+msgid "User account"
+msgstr ""
+
+#. module: poweremail
+#: code:addons/poweremail/poweremail_template.py:0
+#, python-format
+msgid "Warning"
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,sub_object:0
+msgid "When a relation field is used this field will show you the type of field you have selected."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.preview,save_to_drafts_prev:0
+#: help:poweremail.templates,save_to_drafts:0
+msgid "When automatically sending emails generated from this template, save them into the Drafts folder rather than sending them immediately."
+msgstr ""
+
+#. module: poweremail
+#: help:poweremail.templates,sub_model_object_field:0
+msgid "When you choose relationship fields this field will specify the sub value you can use."
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,ref_ir_act_window:0
+msgid "Window Action"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.templates,ref_ir_value:0
+msgid "Wizard Button"
+msgstr ""
+
+#. module: poweremail
+#: selection:poweremail.send.wizard,state:0
+msgid "Wizard Complete"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "Insert Table"
+msgid "Wizard send email"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.core_accounts,ispass:0
-#: field:poweremail.core_accounts,smtppass:0
-msgid "Password"
+#: field:poweremail.templates,attached_wkf:0
+msgid "Workflow"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:946
-#, python-format
-msgid "Starting Header reception for account: %s."
-msgstr ""
-
-#. module: poweremail
-#: field:poweremail.preview,report:0
-msgid "Report Name"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.wizard_poweremail_preview
-msgid "Template Preview"
-msgstr ""
-
-#. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_wizard_change_state_email_form
-#: view:wizard.change.state.email:0
-msgid "Canviar estat dels emails"
+#: selection:poweremail.core_accounts,company:0
+msgid "Yes"
 msgstr ""
 
 #. module: poweremail
 #: view:poweremail.templates:0
-msgid "OpenObject Code Filter:"
+msgid "context - current context"
 msgstr ""
 
 #. module: poweremail
-#: field:poweremail.templates,def_subject:0
-msgid "Default Subject"
+#: view:poweremail.templates:0
+msgid "cr - database cursor"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.actions.act_window,name:poweremail.action_poweremail_core_accounts_tree_co
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_core_accounts_Personal_co
-msgid "Company Accounts"
+#: help:poweremail.core_accounts,email_id:0
+msgid "eg: yourname@yourdomain.com"
 msgstr ""
 
 #. module: poweremail
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox
-#: model:ir.ui.menu,name:poweremail.menu_poweremail_inbox_company
-msgid "Inbox"
+#: view:poweremail.templates:0
+msgid "o - current object"
 msgstr ""
 
 #. module: poweremail
-#: selection:poweremail.mailbox,mail_type:0
-msgid "Has Attachments"
+#: model:ir.model,name:poweremail.model_poweremail_core_accounts
+msgid "poweremail.core_accounts"
 msgstr ""
 
 #. module: poweremail
-#: view:poweremail.mailbox:0
-msgid "Power Email Inbox"
+#: model:ir.model,name:poweremail.model_poweremail_template_attachment
+msgid "poweremail.template.attachment"
 msgstr ""
 
 #. module: poweremail
-#: code:addons/poweremail/poweremail_core.py:958
-#, python-format
-msgid "IMAP Server Folder Selection Error Account: %s Error: %s."
+#: view:poweremail.core_accounts:0
+msgid "security"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "self - objects pointer"
+msgstr ""
+
+#. module: poweremail
+#: view:poweremail.templates:0
+msgid "uid - current user ID"
+msgstr ""
+
+#. module: poweremail
+#: field:poweremail.conversation,from_abstract:0
+msgid "unknown"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_change_folder_email
+msgid "wizard.change.folder.email"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_change_state_email
+msgid "wizard.change.state.email"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_emails_generats_model
+msgid "wizard.emails.generats.model"
+msgstr ""
+
+#. module: poweremail
+#: model:ir.model,name:poweremail.model_wizard_send_email
+msgid "wizard.send.email"
 msgstr ""
 

--- a/migrations/5.0.26.12.0/post-0002_add_report_xml_view_email_templates.py
+++ b/migrations/5.0.26.12.0/post-0002_add_report_xml_view_email_templates.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from tools import config
+from oopgrade.oopgrade import MigrationHelper
+
+def up(cursor, installed_version):
+    if not installed_version or config.updating_all:
+        return
+
+    helper = MigrationHelper(cursor, 'poweremail')
+
+    helper.init_model('ir.actions.report.xml')
+
+    helper.update_xml_records(
+        xml_path='poweremail_template_view.xml',
+        init_record_ids=[
+            'act_report_xml_view_poweremail'
+        ]
+    )
+
+def down(cursor, installed_version):
+    pass
+
+migrate = up

--- a/migrations/5.0.26.12.0/post-0002_add_report_xml_view_email_templates.py
+++ b/migrations/5.0.26.12.0/post-0002_add_report_xml_view_email_templates.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 from tools import config
+from tools.translate import trans_load
 from oopgrade.oopgrade import MigrationHelper
 
 def up(cursor, installed_version):
     if not installed_version or config.updating_all:
         return
 
-    helper = MigrationHelper(cursor, 'poweremail')
+    module = 'poweremail'
+    helper = MigrationHelper(cursor, module_name=module)
 
     helper.init_model('ir.actions.report.xml')
 
@@ -16,6 +18,10 @@ def up(cursor, installed_version):
             'act_report_xml_view_poweremail'
         ]
     )
+
+    # Translations
+    trans_load(cursor, '{}/{}/i18n/es_ES.po'.format(config['addons_path'], module), 'es_ES')
+    trans_load(cursor, '{}/{}/i18n/ca_ES.po'.format(config['addons_path'], module), 'ca_ES')
 
 def down(cursor, installed_version):
     pass

--- a/poweremail_template.py
+++ b/poweremail_template.py
@@ -1534,3 +1534,11 @@ class res_groups(osv.osv):
 res_groups()
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+
+class ir_actions_report_xml(osv.osv):
+    _inherit = 'ir.actions.report.xml'
+
+    _columns = {
+        'poweremail_template_ids': fields.one2many('poweremail.templates', 'report_template', 'Email Templates'),
+    }
+ir_actions_report_xml()

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -326,5 +326,18 @@
         <menuitem name="Email Basic Templates" id="menu_poweremail_basic_templates_all"
             parent="menu_poweremail_templates" action="action_poweremail_basic_template_all" />
 
+        <record id="act_report_xml_view_poweremail" model="ir.ui.view">
+            <field name="name">ir.actions.report.xml.poweremail</field>
+            <field name="model">ir.actions.report.xml</field>
+            <field name="inherit_id" ref="base.act_report_xml_view" />
+            <field name="arch" type="xml">
+                <notebook position="inside">
+                    <page string="Related emails" icon="mail-share">
+                        <field name="poweremail_template_ids" colspan="4" nolabel="1"/>
+                    </page>
+                </notebook>
+            </field>
+        </record>
+
     </data>
 </openerp>

--- a/poweremail_template_view.xml
+++ b/poweremail_template_view.xml
@@ -332,7 +332,7 @@
             <field name="inherit_id" ref="base.act_report_xml_view" />
             <field name="arch" type="xml">
                 <notebook position="inside">
-                    <page string="Related emails" icon="mail-share">
+                    <page string="Related email templates" icon="mail-share">
                         <field name="poweremail_template_ids" colspan="4" nolabel="1"/>
                     </page>
                 </notebook>


### PR DESCRIPTION
 # New behavior
- Extends the `ir.actions.report.xml` model in `poweremail` to include a reverse `One2many` relationship (`poweremail_template_ids`) pointing back to `poweremail.templates`.
- Adds an inherited view to the `ir.actions.report.xml` form that introduces a new "Email Templates" tab in the notebook.
- This tab lists all PowerEmail templates that use the current report as their main attachment (`report_template`). This provides immediate visibility into which automated emails rely on a specific report without leaving the report definition view.
- Includes a migration script (`post-0002_add_report_xml_view_email_templates.py`) in milestone `5.0.26.12.0` that initializes the model to register the new field in the database and safely injects the new view record.       
- <img width="1598" height="961" alt="image" src="https://github.com/user-attachments/assets/5eff6d17-7b13-400f-94b9-1501a693276e" />
      
  
# Old behavior
There was no reverse relationship defined on the core report model. To find out which email templates were using a specific report as an attachment, users or developers had to manually cross-reference and search the PowerEmail templates list.
  
# Checklist
  
- [x] Tests (if not implemented, explain why): Not implemented. 
   - There is no complex backend business logic to test.
        
# Related
  
- [ ] TASK-93092
